### PR TITLE
Turn off non-daemon output

### DIFF
--- a/src/dhcpv6.c
+++ b/src/dhcpv6.c
@@ -352,7 +352,7 @@ int dhcpv6_request(enum dhcpv6_msg type)
 	if (timeout == 0)
 		return -1;
 
-	syslog(LOG_NOTICE, "Sending %s (timeout %us)", retx->name, timeout);
+	dhcpv6_syslog(LOG_NOTICE, "Sending %s (timeout %us)", retx->name, timeout);
 
 	uint64_t start = odhcp6c_get_milli_time(), round_start = start, elapsed;
 
@@ -408,7 +408,7 @@ int dhcpv6_request(enum dhcpv6_msg type)
 
 				round_start = odhcp6c_get_milli_time();
 				elapsed = round_start - start;
-				syslog(LOG_NOTICE, "Got a valid reply after "
+				dhcpv6_syslog(LOG_NOTICE, "Got a valid reply after "
 						"%ums", (unsigned)elapsed);
 
 				if (retx->handler_reply)

--- a/src/odhcp6c.h
+++ b/src/odhcp6c.h
@@ -132,6 +132,13 @@ struct dhcpv6_duid {
 } _packed;
 
 
+extern bool log_quiet;
+#define dhcpv6_syslog(level, ...) \
+	if (!log_quiet) {                \
+		syslog(level, __VA_ARGS__);   \
+	}
+
+
 #define dhcpv6_for_each_option(start, end, otype, olen, odata)\
 	for (uint8_t *_o = (uint8_t*)(start); _o + 4 <= (uint8_t*)(end) &&\
 		((otype) = _o[0] << 8 | _o[1]) && ((odata) = (void*)&_o[4]) &&\


### PR DESCRIPTION
New option '-q' turns off output when odhcp6c is run in non-daemon mode.
