### PR TITLE
Add user-class option in help text and minor clean up

### DIFF
--- a/src/dhcpv6.c
+++ b/src/dhcpv6.c
@@ -188,7 +188,6 @@ int init_dhcpv6(const char *ifname, unsigned int options, int sol_timeout)
 	setsockopt(sock, IPPROTO_IPV6, IPV6_V6ONLY, &val, sizeof(val));
 	setsockopt(sock, SOL_SOCKET, SO_REUSEADDR, &val, sizeof(val));
 	setsockopt(sock, IPPROTO_IPV6, IPV6_RECVPKTINFO, &val, sizeof(val));
-	val = 0;
 	setsockopt(sock, SOL_SOCKET, SO_BINDTODEVICE, ifname, strlen(ifname));
 
 	struct sockaddr_in6 client_addr = { .sin6_family = AF_INET6,

--- a/src/odhcp6c.c
+++ b/src/odhcp6c.c
@@ -450,6 +450,7 @@ static int usage(void)
 #ifdef EXT_BFD_PING
 	"	-B <interval>	Enable BFD ping check\n"
 #endif
+	"	-u <user-class> Set user-class option string\n"
 	"	-c <clientid>	Override client-ID (base-16 encoded)\n"
 	"	-i <iface-id>	Use a custom interface identifier for RA handling\n"
 	"	-r <options>	Options to be requested (comma-separated)\n"


### PR DESCRIPTION
Hi Steven,

Added user-class option in the help text and a minor clean up in the init_dhcpv6 function.
Regarding the enabling of multicast loop feature what's the main use case behind it ?

Bye,
Hans
