### PR TITLE
Handle NoAddrsAvail status in advert as well.

### DIFF
--- a/src/dhcpv6.c
+++ b/src/dhcpv6.c
@@ -773,6 +773,7 @@ static int dhcpv6_handle_advert(enum dhcpv6_msg orig, const int rc,
 			int error = ((int)odata[0] << 8 | (int)odata[1]);
 
 			switch (error) {
+			case DHCPV6_NoAddrsAvail:
 			case DHCPV6_NoPrefixAvail:
 				// Status code on global level
 				cand.preference -= 2000;


### PR DESCRIPTION
RFC 3315 Section 17.1.3.
   The client MUST ignore any Advertise message that includes a Status
   Code option containing the value NoAddrsAvail, with the exception
   that the client MAY display the associated status message to the
   user.

This should fix this omission.
Seen in the wild from comcast.
