### PR TITLE
odhcp6c: Set bound state true before script_call in statefull mode

### DIFF
--- a/src/odhcp6c.c
+++ b/src/odhcp6c.c
@@ -336,8 +336,8 @@ int main(_unused int argc, char* const argv[])
 			break;
 
 		case DHCPV6_STATEFUL:
-			script_call("bound");
 			bound = true;
+			script_call("bound");
 			syslog(LOG_NOTICE, "entering stateful-mode on %s", ifname);
 
 			while (!signal_usr2 && !signal_term) {


### PR DESCRIPTION
Hi Steven,

Small fix on the patch for IA_PD/IA_NA state info leakage.

Br,
Hans
