### PR TITLE
Minor help string clarification for client-ID

### DIFF
--- a/src/odhcp6c.c
+++ b/src/odhcp6c.c
@@ -429,7 +429,7 @@ static int usage(void)
 	"	-F		Force IPv6-Prefix\n"
 	"	-V <class>	Set vendor-class option (base-16 encoded)\n"
 	"	-u <user-class> Set user-class option string\n"
-	"	-c <clientid>	Override client-ID (base-16 encoded)\n"
+	"	-c <clientid>	Override client-ID (base-16 encoded 16-bit type + value)\n"
 	"	-i <iface-id>	Use a custom interface identifier for RA handling\n"
 	"	-r <options>	Options to be requested (comma-separated)\n"
 	"	-R		Do not request any options except those specified with -r\n"


### PR DESCRIPTION
Document that the value of -c must be a 16-bit type (network byte order) followed by a client-ID value.
For example, to use a UUID based client-ID (type 4, RFC 6355) one could use the following cmdline option:
  -c0004<128_bit_uuid_in_hex>
