### PR TITLE
Add OPTION_AUTH (option 11)

### DIFF
--- a/src/dhcpv6.c
+++ b/src/dhcpv6.c
@@ -222,6 +222,8 @@ enum {
 	IOV_HDR_IA_NA,
 	IOV_IA_NA,
 	IOV_IA_PD,
+	IOV_AUTH_HDR,
+	IOV_AUTH,
 	IOV_TOTAL
 };
 
@@ -434,6 +436,15 @@ static void dhcpv6_send(enum dhcpv6_msg type, uint8_t trid[3], uint32_t ecs)
 		uint16_t length;
 	} user_class_hdr = {htons(DHCPV6_OPT_USER_CLASS), htons(user_class_len)};
 
+	//Build auth option
+	size_t auth_len;
+	struct dhcpv6_auth *auth = odhcp6c_get_state(STATE_AUTH, &auth_len);
+
+	struct {
+		uint16_t type;
+		uint16_t length;
+	} auth_hdr = {htons(DHCPV6_OPT_AUTH), htons(auth_len)};
+
 	// Prepare Header
 	size_t oro_len;
 	void *oro = odhcp6c_get_state(STATE_ORO, &oro_len);
@@ -467,15 +478,17 @@ static void dhcpv6_send(enum dhcpv6_msg type, uint8_t trid[3], uint32_t ecs)
 		[IOV_HDR_IA_NA] = {&hdr_ia_na, sizeof(hdr_ia_na)},
 		[IOV_IA_NA] = {ia_na, ia_na_len},
 		[IOV_IA_PD] = {ia_pd, ia_pd_len},
+		[IOV_AUTH_HDR] = {&auth_hdr, auth_len ? sizeof(auth_hdr) : 0},
+		[IOV_AUTH] = {auth, auth_len},
 	};
 
 	size_t cnt = IOV_TOTAL;
 	if (type == DHCPV6_MSG_INFO_REQ) {
-		cnt = 9;
+		cnt = 11;
 		iov[IOV_ORO_REFRESH].iov_len = sizeof(oro_refresh);
 		hdr.oro_len = htons(oro_len + sizeof(oro_refresh));
 	} else if (!request_prefix) {
-		cnt = 13;
+		cnt = 15;
 	}
 
 	// Disable IAs if not used

--- a/src/odhcp6c.c
+++ b/src/odhcp6c.c
@@ -75,7 +75,7 @@ int main(_unused int argc, char* const argv[])
 	int c;
 	unsigned int client_options = DHCPV6_CLIENT_FQDN | DHCPV6_ACCEPT_RECONFIGURE;
 
-	while ((c = getopt(argc, argv, "S::N:V:P:FB:c:i:r:Ru:s:kt:m:hedp:fav")) != -1) {
+	while ((c = getopt(argc, argv, "S::N:V:A:P:FB:c:i:r:Ru:s:kt:m:hedp:fav")) != -1) {
 		switch (c) {
 		case 'S':
 			allow_slaac_only = (optarg) ? atoi(optarg) : -1;
@@ -102,6 +102,16 @@ int main(_unused int argc, char* const argv[])
 			odhcp6c_add_state(STATE_VENDORCLASS, buf, l);
 
 			break;
+
+		case 'A':
+			l = script_unhexlify(buf, sizeof(buf), optarg);
+			if (!l)
+				help=true;
+
+			odhcp6c_add_state(STATE_AUTH, buf, l);
+
+			break;
+			
 		case 'P':
 			if (ia_pd_mode == IA_MODE_NONE)
 				ia_pd_mode = IA_MODE_TRY;
@@ -432,6 +442,7 @@ static int usage(void)
 	"	-P <length>	Request IPv6-Prefix (0 = auto)\n"
 	"	-F		Force IPv6-Prefix\n"
 	"	-V <class>	Set vendor-class option (base-16 encoded)\n"
+	"	-A <hex-string> Set auth option (base-16 encoded)\n"
 	"	-u <user-class> Set user-class option string\n"
 	"	-c <clientid>	Override client-ID (base-16 encoded 16-bit type + value)\n"
 	"	-i <iface-id>	Use a custom interface identifier for RA handling\n"

--- a/src/odhcp6c.h
+++ b/src/odhcp6c.h
@@ -265,6 +265,7 @@ enum odhcp6c_state {
 	STATE_S46_MAPE,
 	STATE_S46_LW,
 	STATE_PASSTHRU,
+	STATE_AUTH,
 	_STATE_MAX
 };
 


### PR DESCRIPTION
My ISP request the AUTH option to get a DHCPv6 lease.
This would close openwrt/odhcp6c#48 (even if the issue name is misleading, but I opened it only for this option to be included)