### PR TITLE
Add option to ignore default lifetime for RDNSS records

### DIFF
--- a/src/odhcp6c.c
+++ b/src/odhcp6c.c
@@ -74,8 +74,9 @@ int main(_unused int argc, char* const argv[])
 	int logopt = LOG_PID;
 	int c;
 	unsigned int client_options = DHCPV6_CLIENT_FQDN | DHCPV6_ACCEPT_RECONFIGURE;
+	unsigned int ra_options = RA_RDNSS_DEFAULT_LIFETIME;
 
-	while ((c = getopt(argc, argv, "S::N:V:P:FB:c:i:r:Ru:s:kt:m:hedp:fav")) != -1) {
+	while ((c = getopt(argc, argv, "S::N:V:P:FB:c:i:r:Ru:s:kt:m:Lhedp:fav")) != -1) {
 		switch (c) {
 		case 'S':
 			allow_slaac_only = (optarg) ? atoi(optarg) : -1;
@@ -193,6 +194,10 @@ int main(_unused int argc, char* const argv[])
 			min_update_interval = atoi(optarg);
 			break;
 
+		case 'L':
+			ra_options &= ~RA_RDNSS_DEFAULT_LIFETIME;
+			break;
+
 		case 'e':
 			logopt |= LOG_PERROR;
 			break;
@@ -244,7 +249,8 @@ int main(_unused int argc, char* const argv[])
 
 	if ((urandom_fd = open("/dev/urandom", O_CLOEXEC | O_RDONLY)) < 0 ||
 			init_dhcpv6(ifname, client_options, sol_timeout) ||
-			ra_init(ifname, &ifid) || script_init(script, ifname)) {
+			ra_init(ifname, &ifid, ra_options) ||
+			script_init(script, ifname)) {
 		syslog(LOG_ERR, "failed to initialize: %s", strerror(errno));
 		return 3;
 	}
@@ -443,6 +449,7 @@ static int usage(void)
 	"	-k		Don't send a RELEASE when stopping\n"
 	"	-t <seconds>	Maximum timeout for DHCPv6-SOLICIT (120)\n"
 	"	-m <seconds>	Minimum time between accepting updates (30)\n"
+	"	-L		Ignore default lifetime for RDNSS records\n"
 	"\nInvocation options:\n"
 	"	-p <pidfile>	Set pidfile (/var/run/odhcp6c.pid)\n"
 	"	-d		Daemonize\n"

--- a/src/odhcp6c.h
+++ b/src/odhcp6c.h
@@ -282,6 +282,10 @@ enum dhcpv6_mode {
 	DHCPV6_STATEFUL
 };
 
+enum ra_config {
+	RA_RDNSS_DEFAULT_LIFETIME = 1,
+};
+
 enum odhcp6c_ia_mode {
 	IA_MODE_NONE,
 	IA_MODE_TRY,

--- a/src/ra.h
+++ b/src/ra.h
@@ -34,6 +34,6 @@ struct icmpv6_opt {
 	(void*)(opt + opt->len) <= (void*)(end); opt += opt->len)
 
 
-int ra_init(const char *ifname, const struct in6_addr *ifid);
+int ra_init(const char *ifname, const struct in6_addr *ifid, unsigned int options);
 bool ra_link_up(void);
 bool ra_process(void);


### PR DESCRIPTION
As discussed in #21:

While RFC6106 mandates that the RDNSS lifetime is capped to the default
lifetime, this behaviour is often undesirable. In particular, it prevents
accepting RDNSS records from RAs that don't also advertise a default route
(set the default lifetime to 0).

Therefore, make it possible to opt out of this behaviour and respect the
RDNSS lifetime independently of the default lifetime using the new command
line switch -L.

Any suggestions for the UCI option name? I'd probably go with `dnsdefaultlifetime` (defaulting to 1), which is long and doesn't really say a lot...