### PR TITLE
odhcp6c: add option to ignore Server Unicast option

### DIFF
--- a/src/dhcpv6.c
+++ b/src/dhcpv6.c
@@ -856,7 +856,9 @@ static int dhcpv6_handle_advert(enum dhcpv6_msg orig, const int rc,
 				cand.preference >= 0) {
 			cand.preference = pref = odata[0];
 		} else if (otype == DHCPV6_OPT_UNICAST && olen == sizeof(cand.server_addr)) {
-			cand.server_addr = *(struct in6_addr *)odata;
+			if (!(client_options & DHCPV6_IGNORE_OPT_UNICAST)) {
+				cand.server_addr = *(struct in6_addr *)odata;
+			}
 		} else if (otype == DHCPV6_OPT_RECONF_ACCEPT) {
 			cand.wants_reconfigure = true;
 		} else if (otype == DHCPV6_OPT_SOL_MAX_RT && olen == 4) {
@@ -1048,8 +1050,11 @@ static int dhcpv6_handle_reply(enum dhcpv6_msg orig, _unused const int rc,
 					continue;
 
 				updated_IAs += dhcpv6_parse_ia(ia_hdr, odata + olen);
-			} else if (otype == DHCPV6_OPT_UNICAST && olen == sizeof(server_addr))
-				server_addr = *(struct in6_addr *)odata;
+			} else if (otype == DHCPV6_OPT_UNICAST && olen == sizeof(server_addr)) {
+				if (!(client_options & DHCPV6_IGNORE_OPT_UNICAST)) {
+					server_addr = *(struct in6_addr *)odata;
+				}
+			}
 			else if (otype == DHCPV6_OPT_STATUS && olen >= 2) {
 				uint8_t *mdata = (olen > 2) ? &odata[2] : NULL;
 				uint16_t mlen = (olen > 2) ? olen - 2 : 0;

--- a/src/odhcp6c.c
+++ b/src/odhcp6c.c
@@ -138,7 +138,7 @@ int main(_unused int argc, char* const argv[])
 	unsigned int ra_options = RA_RDNSS_DEFAULT_LIFETIME;
 	unsigned int ra_holdoff_interval = RA_MIN_ADV_INTERVAL;
 
-	while ((c = getopt(argc, argv, "S::N:V:P:FB:c:i:r:Ru:x:s:kt:m:Lhedp:fav")) != -1) {
+	while ((c = getopt(argc, argv, "S::N:V:P:FB:c:i:r:Ru:Ux:s:kt:m:Lhedp:fav")) != -1) {
 		switch (c) {
 		case 'S':
 			allow_slaac_only = (optarg) ? atoi(optarg) : -1;
@@ -278,6 +278,10 @@ int main(_unused int argc, char* const argv[])
 				help = true;
 
 			free(o_data);
+			break;
+
+		case 'U':
+			client_options |= DHCPV6_IGNORE_OPT_UNICAST;
 			break;
 
 		case 's':
@@ -572,6 +576,7 @@ static int usage(void)
 	"	-t <seconds>	Maximum timeout for DHCPv6-SOLICIT (120)\n"
 	"	-m <seconds>	Minimum time between accepting RA updates (3)\n"
 	"	-L		Ignore default lifetime for RDNSS records\n"
+	"	-U		Ignore Server Unicast option\n"
 	"\nInvocation options:\n"
 	"	-p <pidfile>	Set pidfile (/var/run/odhcp6c.pid)\n"
 	"	-d		Daemonize\n"

--- a/src/odhcp6c.h
+++ b/src/odhcp6c.h
@@ -119,6 +119,7 @@ enum dhcpv6_config {
 	DHCPV6_STRICT_OPTIONS = 1,
 	DHCPV6_CLIENT_FQDN = 2,
 	DHCPV6_ACCEPT_RECONFIGURE = 4,
+	DHCPV6_IGNORE_OPT_UNICAST = 8,
 };
 
 typedef int(reply_handler)(enum dhcpv6_msg orig, const int rc,


### PR DESCRIPTION
Hi

My ISP has a problem and odhcp6c never gets a reply to renew messages, if sent to the server's unicast address, so I added this option as a workaround to ignore the Unicast Server Option. With that all renew messages are sent to the multicast address.

The problem is further discussed here: https://forum.turris.cz/t/turris-os-3-10-dhcpv6-loses-address-after-1-hour/7391

I can send you pcap files if you want.

Cheers,
Adi