### PR TITLE
odhcp6c: fix IA discard when T1 > 0 and T2 = 0

### DIFF
--- a/src/dhcpv6.c
+++ b/src/dhcpv6.c
@@ -1343,7 +1343,7 @@ static unsigned int dhcpv6_parse_ia(void *opt, void *end)
 	t1 = ntohl(ia_hdr->t1);
 	t2 = ntohl(ia_hdr->t2);
 
-	if (t1 > t2)
+	if (t1 > t2 && t1 > 0 && t2 > 0)
 		return 0;
 
 	syslog(LOG_INFO, "%s %04x T1 %d T2 %d", ntohs(ia_hdr->type) == DHCPV6_OPT_IA_PD ? "IA_PD" : "IA_NA", ntohl(ia_hdr->iaid), t1, t2);


### PR DESCRIPTION
My ISP uses DHCPv6 advertisements where IA_PD T1 is non-zero (43200) and
T2 is zero. Current implementation of odhcp6c doesn't handle that and
just switches to stateless mode.

According to RFC 8415, section [21.21](https://datatracker.ietf.org/doc/html/rfc8415#section-21.21):
> If a client receives an IA_PD with T1 greater than T2 and both T1 and
  T2 are greater than 0, the client discards the IA_PD option and
  processes the remainder of the message as though the server had not
  included the IA_PD option.

Currently odhcp6c discards IA_PD option if `t1 > t2`:
https://github.com/openwrt/odhcp6c/blob/39b584bcac8770619b545d6ae344758f87028612/src/dhcpv6.c#L1346-L1347

The same applies for IA_NA.

Fix it by editing IA discard condition according to RFC.

Signed-off-by: Dávid Benko <davidbenko@davidbenko.dev>