### PR TITLE
dhcpv6c: exportable DUID

### DIFF
--- a/src/odhcp6c.h
+++ b/src/odhcp6c.h
@@ -392,7 +392,7 @@ struct odhcp6c_opt {
 	const char *str;
 };
 
-int init_dhcpv6(const char *ifname, unsigned int client_options, int sol_timeout);
+int init_dhcpv6(const char *ifname, unsigned int client_options, int sol_timeout, const char *duid_path);
 int dhcpv6_set_ia_mode(enum odhcp6c_ia_mode na, enum odhcp6c_ia_mode pd, bool stateful_only);
 int dhcpv6_request(enum dhcpv6_msg type);
 int dhcpv6_poll_reconfigure(void);
@@ -408,6 +408,7 @@ int ra_get_reachable(void);
 int ra_get_retransmit(void);
 
 int script_init(const char *path, const char *ifname);
+void script_hexlify(char *dst, const uint8_t *src, size_t len);
 ssize_t script_unhexlify(uint8_t *dst, size_t len, const char *src);
 void script_call(const char *status, int delay, bool resume);
 

--- a/src/script.c
+++ b/src/script.c
@@ -84,7 +84,7 @@ ssize_t script_unhexlify(uint8_t *dst, size_t len, const char *src)
 	return c;
 }
 
-static void script_hexlify(char *dst, const uint8_t *src, size_t len)
+void script_hexlify(char *dst, const uint8_t *src, size_t len)
 {
 	for (size_t i = 0; i < len; ++i) {
 		*dst++ = hexdigits[src[i] >> 4];


### PR DESCRIPTION
Adds a cmdline argument `-C <path>` which exports
the current DUID (per interface) to a file.

The main reason for this is that when DUID is generated
by odhcp6c, it is not possible for other programs
to detect which DUID is actually used.

Signed-off-by: Stepan Henek <stepan.henek@nic.cz>