### PR TITLE
restart DHCPv6 transaction on receival of RA who contains a new prefix

### DIFF
--- a/src/dhcpv6.c
+++ b/src/dhcpv6.c
@@ -1357,7 +1357,7 @@ static unsigned int dhcpv6_parse_ia(void *opt, void *end)
 	// Update address IA
 	dhcpv6_for_each_option(&ia_hdr[1], end, otype, olen, odata) {
 		struct odhcp6c_entry entry = {IN6ADDR_ANY_INIT, 0, 0,
-				IN6ADDR_ANY_INIT, 0, 0, 0, 0, 0, 0};
+				IN6ADDR_ANY_INIT, 0, 0, 0, 0, 0, 0, 0};
 
 		entry.iaid = ia_hdr->iaid;
 

--- a/src/odhcp6c.h
+++ b/src/odhcp6c.h
@@ -348,6 +348,7 @@ struct odhcp6c_entry {
 	uint8_t auxlen;
 	uint8_t length;
 	struct in6_addr target;
+	uint8_t flags;
 	int16_t priority;
 	uint32_t valid;
 	uint32_t preferred;

--- a/src/ra.c
+++ b/src/ra.c
@@ -432,6 +432,7 @@ bool ra_process(void)
 		entry->target = any;
 		entry->length = 0;
 		entry->router = from.sin6_addr;
+		entry->flags = adv->nd_ra_flags_reserved & (ND_RA_FLAG_MANAGED | ND_RA_FLAG_OTHER);
 		entry->priority = pref_to_priority(adv->nd_ra_flags_reserved);
 		if (entry->priority < 0)
 			entry->priority = pref_to_priority(0);
@@ -440,6 +441,7 @@ bool ra_process(void)
 		entry->preferred = entry->valid;
 		changed |= odhcp6c_update_entry(STATE_RA_ROUTE, entry,
 						0, ra_holdoff_interval);
+		entry->flags = 0; // other STATE_RA_* entries don't have flags
 
 		// Parse hoplimit
 		changed |= ra_set_hoplimit(adv->nd_ra_curhoplimit);


### PR DESCRIPTION
When upstream DHCPv6 server does not provide IA_NA or IA_PD options, odhcp6c enters in stateless mode, which will not be exited from until SIGUSR2 signal is received.

This change enforce DHCPv6 transaction restart on receival of a RA that:
  a) advertise the presence of DHCPv6 server in the network, either
     by containing M or O flags
  b) has a PI (prefix information) option that contains a new prefix
thus allowing the switch to DHCPv6 stateful mode when RA PI options suggest that upstream DHCPv6 server now manages a new prefix.

Transaction restart is useful even when DHCPv6 client is already in stateful mode, so DHCPv6 server will be able to refresh client's IA_NA and IA_PD options before renewal timeout is triggered, hence avoiding usage of potentially deprecated addresses.