### PR TITLE
fix odhcp6c deamon raw buffer inc

### DIFF
--- a/src/odhcp6c.c
+++ b/src/odhcp6c.c
@@ -433,20 +433,12 @@ int main(_unused int argc, char* const argv[])
 	signal(SIGUSR1, sighandler);
 	signal(SIGUSR2, sighandler);
 
-	if ((urandom_fd = open("/dev/urandom", O_CLOEXEC | O_RDONLY)) < 0 ||
-			init_dhcpv6(ifname, client_options, sk_prio, sol_timeout) ||
-			ra_init(ifname, &ifid, ra_options, ra_holdoff_interval) ||
-			script_init(script, ifname)) {
-		syslog(LOG_ERR, "failed to initialize: %s", strerror(errno));
-		return 3;
-	}
-
 	if (daemonize) {
 		openlog("odhcp6c", LOG_PID, LOG_DAEMON); // Disable LOG_PERROR
 		if (daemon(0, 0)) {
 			syslog(LOG_ERR, "Failed to daemonize: %s",
 					strerror(errno));
-			return 4;
+			return 3;
 		}
 
 		if (!pidfile) {
@@ -461,7 +453,15 @@ int main(_unused int argc, char* const argv[])
 		}
 	}
 
-	script_call("started", 0, false);
+    if ((urandom_fd = open("/dev/urandom", O_CLOEXEC | O_RDONLY)) < 0 ||
+            init_dhcpv6(ifname, client_options, sk_prio, sol_timeout) ||
+            ra_init(ifname, &ifid, ra_options, ra_holdoff_interval) ||
+            script_init(script, ifname)) {
+        syslog(LOG_ERR, "failed to initialize: %s", strerror(errno));
+        return 4;
+     }
+
+    script_call("started", 0, false);
 
 	while (!signal_term) { // Main logic
 		odhcp6c_clear_state(STATE_SERVER_ID);


### PR DESCRIPTION
When starting odhcp6c as a daemon using the command "odhcp6c -s /etc/odhcp6c.script -p /var/run/eth0_odhcp6c.pid -P 0 -t 120 eth0", the DHCPv6 server sends RA packets every 10 seconds.
However, it was observed that the raw socket's receive buffer keeps increasing continuously.
After investigating the code, an error was found: the I/O signal was bound before starting the daemon, causing the daemon to not receive the I/O signal. Consequently, the raw socket's recv queue kept growing indefinitely.

I have observed that this bug seems to be persistent.

This patch is my solution, which places the initialization after creating the daemon process.