### PR TITLE
odhcp6c: sync and accumulate RA & DHCPv6 events as fast as possible

### DIFF
--- a/src/odhcp6c.c
+++ b/src/odhcp6c.c
@@ -512,7 +512,7 @@ int main(_unused int argc, char* const argv[])
 
 			while (!signal_usr2 && !signal_term) {
 				signal_usr1 = false;
-				script_call("informed", script_sync_delay, true);
+				script_call("informed", ra ? script_accu_delay : script_sync_delay, true);
 
 				res = dhcpv6_poll_reconfigure();
 				odhcp6c_signal_process();
@@ -540,7 +540,7 @@ int main(_unused int argc, char* const argv[])
 
 		case DHCPV6_STATEFUL:
 			bound = true;
-			script_call("bound", script_sync_delay, true);
+			script_call("bound", ra ? script_accu_delay : script_sync_delay, true);
 			syslog(LOG_NOTICE, "entering stateful-mode on %s", ifname);
 
 			while (!signal_usr2 && !signal_term) {


### PR DESCRIPTION
This fixes dc186d6d2b0dd4ad23ca5fc69c00e81f796ff6d9 commit which introduce accumulation delay differences between the 2 possible scenarios:
 1) When DHCPv6 bound event precede RA receival, sync script is called
   after 1 second since accumulation has been completed (i.e. RA has
   been received).
 2) When RA receival precedes DHCPv6 bound event, sync script is called
    after a delay of 10 seconds since accumulation is done.