### PR TITLE
odhcp6c: add option request specific IA_PD

### DIFF
--- a/src/dhcpv6.c
+++ b/src/dhcpv6.c
@@ -105,6 +105,7 @@ static int64_t t1 = 0, t2 = 0, t3 = 0;
 // IA states
 static enum odhcp6c_ia_mode na_mode = IA_MODE_NONE, pd_mode = IA_MODE_NONE;
 static bool stateful_only_mode = false;
+static struct in6_addr pd_prefix_request;
 static bool accept_reconfig = false;
 // Server unicast address
 static struct in6_addr server_addr = IN6ADDR_ANY_INIT;
@@ -321,6 +322,10 @@ enum {
 	IOV_TOTAL
 };
 
+void dhcpv6_set_pd_request_prefix(const char *pd_request_prefix)
+{
+	inet_pton(AF_INET6, pd_request_prefix, &pd_prefix_request);
+}
 int dhcpv6_set_ia_mode(enum odhcp6c_ia_mode na, enum odhcp6c_ia_mode pd, bool stateful_only)
 {
 	int mode = DHCPV6_UNKNOWN;
@@ -384,7 +389,8 @@ static void dhcpv6_send(enum dhcpv6_msg type, uint8_t trid[3], uint32_t ecs)
 			struct dhcpv6_ia_prefix pref = {
 				.type = htons(DHCPV6_OPT_IA_PREFIX),
 				.len = htons(sizeof(pref) - 4),
-				.prefix = request_prefixes[i].length
+				.prefix = request_prefixes[i].length,
+				.addr = pd_prefix_request
 			};
 			memcpy(ia_pd + ia_pd_len, &hdr_ia_pd, sizeof(hdr_ia_pd));
 			ia_pd_len += sizeof(hdr_ia_pd);

--- a/src/odhcp6c.c
+++ b/src/odhcp6c.c
@@ -188,7 +188,7 @@ int main(_unused int argc, char* const argv[])
 	unsigned int ra_options = RA_RDNSS_DEFAULT_LIFETIME;
 	unsigned int ra_holdoff_interval = RA_MIN_ADV_INTERVAL;
 
-	while ((c = getopt(argc, argv, "S::DN:V:P:FB:c:i:r:Ru:Ux:s:kK:t:m:Lhedp:fav")) != -1) {
+	while ((c = getopt(argc, argv, "S::DN:V:I:P:FB:c:i:r:Ru:Ux:s:kK:t:m:Lhedp:fav")) != -1) {
 		switch (c) {
 		case 'S':
 			allow_slaac_only = (optarg) ? atoi(optarg) : -1;
@@ -234,6 +234,9 @@ int main(_unused int argc, char* const argv[])
 			free(o_data);
 			break;
 
+		case 'I':
+			dhcpv6_set_pd_request_prefix(optarg);
+		break;
 		case 'P':
 			if (ia_pd_mode == IA_MODE_NONE)
 				ia_pd_mode = IA_MODE_TRY;
@@ -615,6 +618,7 @@ static int usage(void)
 	"	-D		Discard advertisements without any address or prefix proposed\n"
 	"	-N <mode>	Mode for requesting addresses [try|force|none]\n"
 	"	-P <length>	Request IPv6-Prefix (0 = auto)\n"
+	"	-I <prefix>	Request IPv6-Prefix (-P must be >0)\n"
 	"	-F		Force IPv6-Prefix\n"
 	"	-V <class>	Set vendor-class option (base-16 encoded)\n"
 	"	-u <user-class> Set user-class option string\n"

--- a/src/odhcp6c.h
+++ b/src/odhcp6c.h
@@ -393,6 +393,7 @@ struct odhcp6c_opt {
 };
 
 int init_dhcpv6(const char *ifname, unsigned int client_options, int sk_prio, int sol_timeout);
+void dhcpv6_set_pd_request_prefix(const char *pd_request_prefix);
 int dhcpv6_set_ia_mode(enum odhcp6c_ia_mode na, enum odhcp6c_ia_mode pd, bool stateful_only);
 int dhcpv6_request(enum dhcpv6_msg type);
 int dhcpv6_poll_reconfigure(void);


### PR DESCRIPTION
This adds a command line option (-I) to request DHCPv6 server for the specific IPv6 prefix. This allows in some cases to keep the IPv6 prefix, for example if the prefix is ​​issued dynamically on upstream. Example: odhcp6c -P 60 -I 2001:db8:cafe:20:: eth0