### PR TITLE
odhcp6c: allow to request specific ipv6 prefix

### DIFF
--- a/src/dhcpv6.c
+++ b/src/dhcpv6.c
@@ -384,7 +384,8 @@ static void dhcpv6_send(enum dhcpv6_msg type, uint8_t trid[3], uint32_t ecs)
 			struct dhcpv6_ia_prefix pref = {
 				.type = htons(DHCPV6_OPT_IA_PREFIX),
 				.len = htons(sizeof(pref) - 4),
-				.prefix = request_prefixes[i].length
+				.prefix = request_prefixes[i].length,
+				.addr = request_prefixes[i].addr
 			};
 			memcpy(ia_pd + ia_pd_len, &hdr_ia_pd, sizeof(hdr_ia_pd));
 			ia_pd_len += sizeof(hdr_ia_pd);

--- a/src/odhcp6c.h
+++ b/src/odhcp6c.h
@@ -367,7 +367,8 @@ struct odhcp6c_entry {
 
 struct odhcp6c_request_prefix {
 	uint32_t iaid;
-	uint16_t length;
+	uint8_t length;
+	struct in6_addr addr;
 };
 
 enum odhcp6c_opt_flags {


### PR DESCRIPTION
Expand -P option with optional exact ipv6 prefix format. This allows to keep the IPv6 prefix in some cases, for example if the prefix is issued dynamically on upstream.

Examples:
```
    -P <length>
    -P <prefix/length>
```

Based on https://github.com/openwrt/odhcp6c/pull/86