### PR TITLE
odhcp6c: Do not request S46 OROs by default

### DIFF
--- a/src/dhcpv6.c
+++ b/src/dhcpv6.c
@@ -256,14 +256,10 @@ int init_dhcpv6(const char *ifname, unsigned int options, int sk_prio, int sol_t
 			htons(DHCPV6_OPT_DNS_DOMAIN),
 			htons(DHCPV6_OPT_SNTP_SERVERS),
 			htons(DHCPV6_OPT_NTP_SERVER),
-			htons(DHCPV6_OPT_AFTR_NAME),
 			htons(DHCPV6_OPT_PD_EXCLUDE),
 #ifdef EXT_CER_ID
 			htons(DHCPV6_OPT_CER_ID),
 #endif
-			htons(DHCPV6_OPT_S46_CONT_MAPE),
-			htons(DHCPV6_OPT_S46_CONT_MAPT),
-			htons(DHCPV6_OPT_S46_CONT_LW),
 		};
 		odhcp6c_add_state(STATE_ORO, oro, sizeof(oro));
 	}

--- a/src/odhcp6c.h
+++ b/src/odhcp6c.h
@@ -88,7 +88,7 @@ enum dhcvp6_opt {
 	DHCPV6_OPT_CER_ID = EXT_CER_ID,
 #endif
 	DHCPV6_OPT_DHCPV4_MSG = 87,
-	/* draft-ietf-softwire-map-dhcp-08 */
+	/* RFC 7598 */
 	DHCPV6_OPT_S46_RULE = 89,
 	DHCPV6_OPT_S46_BR = 90,
 	DHCPV6_OPT_S46_DMR = 91,


### PR DESCRIPTION
This prevents odhcp6c from requesting MAP-T/E, LW4o6, and DS-Lite options by default, as the required packages aren't installed by default.

This commit should be merged along with commits to the map and ds-lite packages, that add configuration to requests the OROs when the packages are installed.

Signed-off-by: Richard Patterson <richard@helix.net.nz>