### PR TITLE
if DHCPV6_Success was reached once, then it should not be aborted

### DIFF
--- a/src/dhcpv6.c
+++ b/src/dhcpv6.c
@@ -1149,7 +1149,7 @@ static int dhcpv6_handle_reply(enum dhcpv6_msg orig, _unused const int rc,
 						code = ((int)sdata[0]) << 8 | ((int)sdata[1]);
 
 						if (code == DHCPV6_Success)
-						    dhcpv6_successful_once = true;
+							dhcpv6_successful_once = true;
 							continue;
 
 						dhcpv6_handle_ia_status_code(orig, ia_hdr,

--- a/src/dhcpv6.c
+++ b/src/dhcpv6.c
@@ -1138,6 +1138,7 @@ static int dhcpv6_handle_reply(enum dhcpv6_msg orig, _unused const int rc,
 				uint16_t code = DHCPV6_Success;
 				uint16_t stype, slen;
 				uint8_t *sdata;
+				bool success = false;
 				// Get and handle status code
 				dhcpv6_for_each_option(&ia_hdr[1], odata + olen,
 						stype, slen, sdata) {
@@ -1148,6 +1149,7 @@ static int dhcpv6_handle_reply(enum dhcpv6_msg orig, _unused const int rc,
 						code = ((int)sdata[0]) << 8 | ((int)sdata[1]);
 
 						if (code == DHCPV6_Success)
+						    success = true;
 							continue;
 
 						dhcpv6_handle_ia_status_code(orig, ia_hdr,
@@ -1160,7 +1162,7 @@ static int dhcpv6_handle_reply(enum dhcpv6_msg orig, _unused const int rc,
 					}
 				}
 
-				if (code != DHCPV6_Success)
+				if (!success && code != DHCPV6_Success)
 					continue;
 
 				updated_IAs += dhcpv6_parse_ia(ia_hdr, odata + olen);

--- a/src/dhcpv6.c
+++ b/src/dhcpv6.c
@@ -1138,7 +1138,7 @@ static int dhcpv6_handle_reply(enum dhcpv6_msg orig, _unused const int rc,
 				uint16_t code = DHCPV6_Success;
 				uint16_t stype, slen;
 				uint8_t *sdata;
-				bool success = false;
+				bool dhcpv6_successful_once = false;
 				// Get and handle status code
 				dhcpv6_for_each_option(&ia_hdr[1], odata + olen,
 						stype, slen, sdata) {
@@ -1149,7 +1149,7 @@ static int dhcpv6_handle_reply(enum dhcpv6_msg orig, _unused const int rc,
 						code = ((int)sdata[0]) << 8 | ((int)sdata[1]);
 
 						if (code == DHCPV6_Success)
-						    success = true;
+						    dhcpv6_successful_once = true;
 							continue;
 
 						dhcpv6_handle_ia_status_code(orig, ia_hdr,
@@ -1162,7 +1162,7 @@ static int dhcpv6_handle_reply(enum dhcpv6_msg orig, _unused const int rc,
 					}
 				}
 
-				if (!success && code != DHCPV6_Success)
+				if (!dhcpv6_successful_once && code != DHCPV6_Success)
 					continue;
 
 				updated_IAs += dhcpv6_parse_ia(ia_hdr, odata + olen);


### PR DESCRIPTION
If I'm honest, I have no idea what I'm doing here, but with the change, the IPv6 delegation works for me. I would appreciate it if someone knowledgeable could take a look at this :)

fixes https://github.com/openwrt/odhcp6c/issues/88