### PR TITLE
Add error checking to handle renew failure

### DIFF
--- a/src/odhcp6c.c
+++ b/src/odhcp6c.c
@@ -573,6 +573,9 @@ int main(_unused int argc, char* const argv[])
 				odhcp6c_clear_state(STATE_SERVER_ID); // Remove binding
 				odhcp6c_clear_state(STATE_SERVER_ADDR);
 
+				// Remove any state invalidated by RENEW reply
+				odhcp6c_expire(true);
+
 				size_t ia_pd_len, ia_na_len;
 				odhcp6c_get_state(STATE_IA_PD, &ia_pd_len);
 				odhcp6c_get_state(STATE_IA_NA, &ia_na_len);


### PR DESCRIPTION
Check for error status code in the IA Prefix option in replies to RENEW messages.

This fixes a problem where odhcp6c thinks that renewal succeeded, when actually the upstream router is no longer routing this prefix for us.

See https://github.com/openwrt/odhcp6c/issues/61#issuecomment-2509536512