### PR TITLE
Remove access to uninitialised array

### DIFF
--- a/src/dhcpv6.c
+++ b/src/dhcpv6.c
@@ -68,7 +68,6 @@ static void dhcpv6_handle_status_code(_unused const enum dhcpv6_msg orig,
 static void dhcpv6_handle_ia_status_code(const enum dhcpv6_msg orig,
 		const struct dhcpv6_ia_hdr *ia_hdr, const uint16_t code,
 		const void *status_msg, const int len,
-		bool handled_status_codes[_DHCPV6_Status_Max],
 		int *ret);
 static void dhcpv6_add_server_cand(const struct dhcpv6_server_cand *cand);
 static void dhcpv6_clear_all_server_cand(void);
@@ -1068,7 +1067,6 @@ static int dhcpv6_handle_reply(enum dhcpv6_msg orig, _unused const int rc,
 	int ret = 1;
 	unsigned int state_IAs;
 	unsigned int updated_IAs = 0;
-	bool handled_status_codes[_DHCPV6_Status_Max] = { false, };
 
 	odhcp6c_expire(true);
 
@@ -1152,7 +1150,7 @@ static int dhcpv6_handle_reply(enum dhcpv6_msg orig, _unused const int rc,
 							continue;
 
 						dhcpv6_handle_ia_status_code(orig, ia_hdr,
-							code, mdata, mlen, handled_status_codes, &ret);
+							code, mdata, mlen, &ret);
 
 						if (ret > 0)
 							return ret;
@@ -1582,8 +1580,7 @@ static void dhcpv6_handle_status_code(const enum dhcpv6_msg orig,
 
 static void dhcpv6_handle_ia_status_code(const enum dhcpv6_msg orig,
 		const struct dhcpv6_ia_hdr *ia_hdr, const uint16_t code,
-		const void *status_msg, const int len,
-		bool handled_status_codes[_DHCPV6_Status_Max], int *ret)
+		const void *status_msg, const int len, int *ret)
 {
 	dhcpv6_log_status_code(code, ia_hdr->type == DHCPV6_OPT_IA_NA ?
 		"IA_NA" : "IA_PD", status_msg, len);
@@ -1593,7 +1590,7 @@ static void dhcpv6_handle_ia_status_code(const enum dhcpv6_msg orig,
 		switch (orig) {
 		case DHCPV6_MSG_RENEW:
 		case DHCPV6_MSG_REBIND:
-			if ((*ret > 0) && !handled_status_codes[code])
+			if (*ret > 0)
 				*ret = dhcpv6_request(DHCPV6_MSG_REQUEST);
 			break;
 


### PR DESCRIPTION
Remove an access to an uninitialised array, which is causing error handling to be inadvertently skipped for replies containing IA_PD or IA_NA with an error status code.

`handled_status_codes` is an array of length 7, but only the first element is initialised.  This array looks like it was intended as a mechanism for indicating which status codes should be considered errors, but this mechanism is not actually used.