### PR TITLE
Use GNUInstallDirs macros

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -38,7 +38,8 @@ add_executable(odhcp6c ${SOURCES})
 target_link_libraries(odhcp6c ${LIBRARIES})
 
 # Installation
-install(TARGETS odhcp6c DESTINATION sbin/)
+include(GNUInstallDirs)
+install(TARGETS odhcp6c DESTINATION "${CMAKE_INSTALL_SBINDIR}")
 
 # Packaging information
 set(CPACK_PACKAGE_VERSION "1")


### PR DESCRIPTION
Instead of installing to a hardcoded path, use the macros from GNUInstallDirs. This allows proper override of the directories at build time.

This was discovered because the package failed to build in Fedora with the bin-sbin merge change:

https://fedoraproject.org/wiki/Changes/Unify_bin_and_sbin https://bugzilla.redhat.com/show_bug.cgi?id=2340955