### PR TITLE
dhcpv6: Enforce CLIENT_FQDN option usage per RFC 4704

### DIFF
--- a/src/dhcpv6.c
+++ b/src/dhcpv6.c
@@ -585,6 +585,15 @@ static void dhcpv6_send(enum dhcpv6_msg type, uint8_t trid[3], uint32_t ecs)
 	if (!(client_options & DHCPV6_CLIENT_FQDN))
 		iov[IOV_FQDN].iov_len = 0;
 
+	/*
+	 * RFC 4704: A client MUST only include the Client FQDN option in
+	 * SOLICIT, REQUEST, RENEW, or REBIND messages
+	 */
+	if (!(type == DHCPV6_MSG_SOLICIT || type == DHCPV6_MSG_REQUEST ||
+			type == DHCPV6_MSG_RENEW || type == DHCPV6_MSG_REBIND)) {
+		iov[IOV_FQDN].iov_len = 0;
+	}
+
 	struct sockaddr_in6 srv = {AF_INET6, htons(DHCPV6_SERVER_PORT),
 		0, ALL_DHCPV6_RELAYS, ifindex};
 	struct msghdr msg = {.msg_name = &srv, .msg_namelen = sizeof(srv),


### PR DESCRIPTION
According to RFC 4704, a client MUST only include the Client FQDN option in SOLICIT, REQUEST, RENEW, or REBIND messages.

Some DHCPv6 server implementations that strictly follow the RFC may ignore messages where the Client FQDN option appears in disallowed message types (e.g., RELEASE). Some may even disregard subsequent messages from the client after encountering such malformed messages, potentially leading to various issues.

This change ensures the Client FQDN option is used strictly according to the RFC.