### PR TITLE
Add compatibility for CMake 4.0

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8)
+cmake_minimum_required(VERSION 2.8...4.0)
 cmake_policy(SET CMP0015 NEW)
 
 # Project Definition


### PR DESCRIPTION
Update cmake_minimum_required macro to allow using CMake 4.0, which is planned to be used in Fedora 43.

https://bugzilla.redhat.com/show_bug.cgi?id=2380959 https://fedoraproject.org/wiki/Changes/CMake4.0