### PR TITLE
odhcp6c: update cmake file

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,56 +1,69 @@
-cmake_minimum_required(VERSION 3.10)
+cmake_minimum_required(VERSION 3.13)
 cmake_policy(SET CMP0015 NEW)
 
+
 # Project Definition
-project(odhcp6c C)
-set(CMAKE_SHARED_LIBRARY_LINK_C_FLAGS "")
-set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -g3 -std=c99")
-add_definitions(-D_GNU_SOURCE -Os -Wall -Werror -pedantic)
-IF(CMAKE_C_COMPILER_VERSION VERSION_GREATER 6)
-	add_definitions(-Wextra -Werror=implicit-function-declaration)
-	add_definitions(-Wformat -Werror=format-security -Werror=format-nonliteral)
-ENDIF()
-add_definitions(-Wno-unused-parameter -Wmissing-declarations)
+project(odhcp6c LANGUAGES C)
+add_executable(${PROJECT_NAME})
+target_sources(${PROJECT_NAME} PRIVATE
+	src/odhcp6c.c
+	src/dhcpv6.c
+	src/ra.c
+	src/script.c
+)
 
-if(${EXT_PREFIX_CLASS})
-	add_definitions(-DEXT_PREFIX_CLASS=${EXT_PREFIX_CLASS})
-endif(${EXT_PREFIX_CLASS})
 
-if(${EXT_CER_ID})
-	add_definitions(-DEXT_CER_ID=${EXT_CER_ID})
+# Compiler Options
+set_target_properties(${PROJECT_NAME} PROPERTIES C_STANDARD 11)
+target_compile_definitions(${PROJECT_NAME} PRIVATE _GNU_SOURCE)
+target_compile_options(${PROJECT_NAME} PRIVATE -g3)
+target_compile_options(${PROJECT_NAME} PRIVATE -Os)
+target_compile_options(${PROJECT_NAME} PRIVATE -Wall)
+target_compile_options(${PROJECT_NAME} PRIVATE -Werror)
+target_compile_options(${PROJECT_NAME} PRIVATE -pedantic)
+target_compile_options(${PROJECT_NAME} PRIVATE -Wextra)
+target_compile_options(${PROJECT_NAME} PRIVATE -Werror=implicit-function-declaration)
+target_compile_options(${PROJECT_NAME} PRIVATE -Wformat)
+target_compile_options(${PROJECT_NAME} PRIVATE -Werror=format-security)
+target_compile_options(${PROJECT_NAME} PRIVATE -Werror=format-nonliteral)
+target_compile_options(${PROJECT_NAME} PRIVATE -Wno-unused-parameter)
+target_compile_options(${PROJECT_NAME} PRIVATE -Wmissing-declarations)
+
+
+# Libraries
+target_link_libraries(${PROJECT_NAME} PRIVATE resolv)
+
+if (${USE_LIBUBOX})
+	target_compile_definitions(${PROJECT_NAME} PRIVATE USE_LIBUBOX)
+	find_path(ubox_include_dir libubox/md5.h)
+	target_include_directories(${PROJECT_NAME} PRIVATE ${ubox_include_dir})
+	find_library(libubox ubox)
+	target_link_libraries(${PROJECT_NAME} PRIVATE ${libubox})
+else (${USE_LIBUBOX})
+	target_sources(${PROJECT_NAME} PRIVATE src/md5.c)
+endif(${USE_LIBUBOX})
+
+
+# Optional Features
+if (${EXT_CER_ID})
+	target_compile_definitions(${PROJECT_NAME} PRIVATE EXT_CER_ID=${EXT_CER_ID})
 endif(${EXT_CER_ID})
 
-set(SOURCES src/odhcp6c.c src/dhcpv6.c src/ra.c src/script.c)
+if (${EXT_PREFIX_CLASS})
+	target_compile_definitions(${PROJECT_NAME} PRIVATE EXT_PREFIX_CLASS=${EXT_PREFIX_CLASS})
+endif(${EXT_PREFIX_CLASS})
 
-set(LIBRARIES resolv)
-
-if(USE_LIBUBOX)
-	add_definitions(-DUSE_LIBUBOX)
-	find_library(libubox ubox)
-	set(LIBRARIES ${LIBRARIES} ${libubox})
-	FIND_PATH(ubox_include_dir libubox/md5.h)
-	INCLUDE_DIRECTORIES(${ubox_include_dir})
-else()
-	set(SOURCES ${SOURCES} src/md5.c)
-endif()
-
-add_executable(odhcp6c ${SOURCES})
-
-target_link_libraries(odhcp6c ${LIBRARIES})
 
 # Installation
-include(GNUInstallDirs)
-install(TARGETS odhcp6c DESTINATION "${CMAKE_INSTALL_SBINDIR}")
+install(TARGETS ${PROJECT_NAME} DESTINATION sbin/)
+
 
 # Packaging information
 set(CPACK_PACKAGE_VERSION "1")
 set(CPACK_PACKAGE_CONTACT "Steven Barth <steven@midlink.org>")
-set(CPACK_PACKAGE_DESCRIPTION_SUMMARY "6ac")
+set(CPACK_PACKAGE_DESCRIPTION_SUMMARY "${PROJECT_NAME}")
 set(CPACK_GENERATOR "DEB;RPM;STGZ")
 set(CPACK_STRIP_FILES true)
-
 SET(CPACK_DEBIAN_PACKAGE_VERSION ${CPACK_PACKAGE_VERSION})
 set(CPACK_PACKAGE_FILE_NAME "${PROJECT_NAME}_${CPACK_DEBIAN_PACKAGE_VERSION}")
-
 include(CPack)
-


### PR DESCRIPTION
Now that the minimum cmake version has been bumped to 3.13, the cmake file can be modernized a bit. Although it might look like a lot of changes, most of them are quite straightforward.

Every library is located in a consistent manner (allowing command-line overrides of library locations, useful for local development, and also makes it trivial to do static linking, if desired).

The compiler flags have been broken up to have one per line (making it easy in the future to add/remove flags, which would create a simple one-line diff).

Although it might look like this bumps the C standard level, cmake is actually smart enough to pick an earlier version if C11 isn't supported by the compiler (quite unlikely on any versions of gcc currently in use in OpenWrt and even on old distros).

Based on @Alphix's [work for odhcpd](https://github.com/openwrt/odhcpd/commit/c2810fe8b681238cab8a3be1a8ae0cc222514306)