### PR TITLE
odhcp6c: apply draft-ietf-6man-slaac-renum-11 lifetime rules

### DIFF
--- a/src/dhcpv6.c
+++ b/src/dhcpv6.c
@@ -1742,7 +1742,7 @@ static unsigned int dhcpv6_parse_ia(void *opt, void *end, int *ret)
 			}
 
 			if (update_state) {
-				if (odhcp6c_update_entry(STATE_IA_PD, &entry, 0, 0))
+				if (odhcp6c_update_entry(STATE_IA_PD, &entry, 0))
 					updated_IAs++;
 
 				syslog(LOG_INFO, "%s/%d preferred %d valid %d",
@@ -1797,7 +1797,7 @@ static unsigned int dhcpv6_parse_ia(void *opt, void *end, int *ret)
 			}
 
 			if (update_state) {
-				if (odhcp6c_update_entry(STATE_IA_NA, &entry, 0, 0))
+				if (odhcp6c_update_entry(STATE_IA_NA, &entry, 0))
 					updated_IAs++;
 
 				syslog(LOG_INFO, "%s preferred %d valid %d",

--- a/src/odhcp6c.h
+++ b/src/odhcp6c.h
@@ -576,7 +576,7 @@ void* odhcp6c_get_state(enum odhcp6c_state state, size_t *len);
 
 // Entry manipulation
 bool odhcp6c_update_entry(enum odhcp6c_state state, struct odhcp6c_entry *new,
-				uint32_t safe, unsigned int holdoff_interval);
+				unsigned int holdoff_interval);
 
 void odhcp6c_expire(bool expire_ia_pd);
 uint32_t odhcp6c_elapsed(void);


### PR DESCRIPTION
Instead of applying the complicated ruleset from RFC 4862, just use the new address information as described in the draft draft-ietf-6man-slaac-renum-11.