### PR TITLE
treewide: Replace _unused with _o_unused

### DIFF
--- a/src/dhcpv6.c
+++ b/src/dhcpv6.c
@@ -56,7 +56,7 @@ static bool dhcpv6_response_is_valid(const void *buf, ssize_t len,
 static unsigned int dhcpv6_parse_ia(void *opt, void *end, int *ret);
 
 static unsigned int dhcpv6_calc_refresh_timers(void);
-static void dhcpv6_handle_status_code(_unused const enum dhcpv6_msg orig,
+static void dhcpv6_handle_status_code(_o_unused const enum dhcpv6_msg orig,
 		const uint16_t code, const void *status_msg, const int len,
 		int *ret);
 static void dhcpv6_handle_ia_status_code(const enum dhcpv6_msg orig,
@@ -1135,7 +1135,7 @@ static bool dhcpv6_response_is_valid(const void *buf, ssize_t len,
 }
 
 static int dhcpv6_handle_reconfigure(enum dhcpv6_msg orig, const int rc,
-		const void *opt, const void *end, _unused const struct sockaddr_in6 *from)
+		const void *opt, const void *end, _o_unused const struct sockaddr_in6 *from)
 {
 	uint16_t otype, olen;
 	uint8_t *odata;
@@ -1172,7 +1172,7 @@ static int dhcpv6_handle_reconfigure(enum dhcpv6_msg orig, const int rc,
 
 // Collect all advertised servers
 static int dhcpv6_handle_advert(enum dhcpv6_msg orig, const int rc,
-		const void *opt, const void *end, _unused const struct sockaddr_in6 *from)
+		const void *opt, const void *end, _o_unused const struct sockaddr_in6 *from)
 {
 	uint16_t olen, otype;
 	uint8_t *odata, pref = 0;
@@ -1288,7 +1288,7 @@ static int dhcpv6_handle_rebind_reply(enum dhcpv6_msg orig, const int rc,
 	return dhcpv6_handle_reply(orig, rc, opt, end, from);
 }
 
-static int dhcpv6_handle_reply(enum dhcpv6_msg orig, _unused const int rc,
+static int dhcpv6_handle_reply(enum dhcpv6_msg orig, _o_unused const int rc,
 		const void *opt, const void *end, const struct sockaddr_in6 *from)
 {
 	uint8_t *odata;

--- a/src/odhcp6c.c
+++ b/src/odhcp6c.c
@@ -163,7 +163,7 @@ static struct odhcp6c_opt opts[] = {
 	{ .code = 0, .flags = 0, .str = NULL },
 };
 
-int main(_unused int argc, char* const argv[])
+int main(_o_unused int argc, char* const argv[])
 {
 	static struct in6_addr ifid = IN6ADDR_ANY_INIT;
 	// Allocate resources

--- a/src/odhcp6c.h
+++ b/src/odhcp6c.h
@@ -20,9 +20,9 @@
 #include <stdbool.h>
 #include <stdint.h>
 
-#define _unused __attribute__((unused))
-#define _packed __attribute__((packed))
-#define _aligned(n) __attribute__((aligned(n)))
+#define _o_unused __attribute__((unused))
+#define _o_packed __attribute__((packed))
+#define _o_aligned(n) __attribute__((aligned(n)))
 
 #define ARRAY_SIZE(arr) (sizeof(arr) / sizeof((arr)[0]))
 
@@ -256,7 +256,7 @@ struct dhcpv6_ia_hdr {
 	uint32_t iaid;
 	uint32_t t1;
 	uint32_t t2;
-} _packed;
+} _o_packed;
 
 struct dhcpv6_ia_addr {
 	uint16_t type;
@@ -264,7 +264,7 @@ struct dhcpv6_ia_addr {
 	struct in6_addr addr;
 	uint32_t preferred;
 	uint32_t valid;
-} _packed;
+} _o_packed;
 
 struct dhcpv6_ia_prefix {
 	uint16_t type;
@@ -273,14 +273,14 @@ struct dhcpv6_ia_prefix {
 	uint32_t valid;
 	uint8_t prefix;
 	struct in6_addr addr;
-} _packed;
+} _o_packed;
 
 struct dhcpv6_duid {
 	uint16_t type;
 	uint16_t len;
 	uint16_t duid_type;
 	uint8_t data[128];
-} _packed;
+} _o_packed;
 
 struct dhcpv6_auth {
 	uint16_t type;
@@ -290,35 +290,35 @@ struct dhcpv6_auth {
 	uint8_t rdm;
 	uint64_t replay;
 	uint8_t data[];
-} _packed;
+} _o_packed;
 
 struct dhcpv6_auth_reconfigure {
 	uint8_t reconf_type;
 	uint8_t key[16];
-} _packed;
+} _o_packed;
 
 struct dhcpv6_cer_id {
 	uint16_t type;
 	uint16_t len;
 	struct in6_addr addr;
-} _packed;
+} _o_packed;
 
 struct dhcpv6_s46_portparams {
 	uint8_t offset;
 	uint8_t psid_len;
 	uint16_t psid;
-} _packed;
+} _o_packed;
 
 struct dhcpv6_s46_v4v6bind {
 	struct in_addr ipv4_address;
 	uint8_t bindprefix6_len;
 	uint8_t bind_ipv6_prefix[];
-} _packed;
+} _o_packed;
 
 struct dhcpv6_s46_dmr {
 	uint8_t dmr_prefix6_len;
 	uint8_t dmr_ipv6_prefix[];
-} _packed;
+} _o_packed;
 
 struct dhcpv6_s46_rule {
 	uint8_t flags;
@@ -327,7 +327,7 @@ struct dhcpv6_s46_rule {
 	struct in_addr ipv4_prefix;
 	uint8_t prefix6_len;
 	uint8_t ipv6_prefix[];
-} _packed;
+} _o_packed;
 
 #define dhcpv6_for_each_option(start, end, otype, olen, odata)\
 	for (uint8_t *_o = (uint8_t*)(start); _o + 4 <= (uint8_t*)(end) &&\

--- a/src/ra.c
+++ b/src/ra.c
@@ -350,7 +350,7 @@ bool ra_process(void)
 {
 	bool found = false;
 	bool changed = false;
-	uint8_t buf[1500] _aligned(4);
+	uint8_t buf[1500] _o_aligned(4);
 	union {
 		struct cmsghdr hdr;
 		uint8_t buf[CMSG_SPACE(sizeof(int))];

--- a/src/ubus.c
+++ b/src/ubus.c
@@ -599,9 +599,9 @@ static int states_to_blob(void)
 	return UBUS_STATUS_OK;
 }
 
-static int ubus_handle_get_stats(struct ubus_context *ctx, _unused struct ubus_object *obj,
-		struct ubus_request_data *req, _unused const char *method,
-		_unused struct blob_attr *msg)
+static int ubus_handle_get_stats(struct ubus_context *ctx, _o_unused struct ubus_object *obj,
+		struct ubus_request_data *req, _o_unused const char *method,
+		_o_unused struct blob_attr *msg)
 {
 	struct dhcpv6_stats stats = dhcpv6_get_stats();
 
@@ -626,18 +626,18 @@ static int ubus_handle_get_stats(struct ubus_context *ctx, _unused struct ubus_o
 	return UBUS_STATUS_OK;
 }
 
-static int ubus_handle_reset_stats(_unused struct ubus_context *ctx, _unused struct ubus_object *obj,
-		_unused struct ubus_request_data *req, _unused const char *method,
-		_unused struct blob_attr *msg)
+static int ubus_handle_reset_stats(_o_unused struct ubus_context *ctx, _o_unused struct ubus_object *obj,
+		_o_unused struct ubus_request_data *req, _o_unused const char *method,
+		_o_unused struct blob_attr *msg)
 {
 	dhcpv6_reset_stats();
 
 	return UBUS_STATUS_OK;
 }
 
-static int ubus_handle_get_state(struct ubus_context *ctx, _unused struct ubus_object *obj,
-		struct ubus_request_data *req, _unused const char *method,
-		_unused struct blob_attr *msg)
+static int ubus_handle_get_state(struct ubus_context *ctx, _o_unused struct ubus_object *obj,
+		struct ubus_request_data *req, _o_unused const char *method,
+		_o_unused struct blob_attr *msg)
 {
 	CHECK(states_to_blob());
 	CHECK(ubus_send_reply(ctx, req, b.head));
@@ -684,8 +684,8 @@ static int ubus_handle_reconfigure_dhcp_rtx(enum config_dhcp_msg msg, struct blo
 	return UBUS_STATUS_OK;
 }
 
-static int ubus_handle_reconfigure_dhcp(_unused struct ubus_context *ctx, _unused struct ubus_object *obj,
-		_unused struct ubus_request_data *req, _unused const char *method,
+static int ubus_handle_reconfigure_dhcp(_o_unused struct ubus_context *ctx, _o_unused struct ubus_object *obj,
+		_o_unused struct ubus_request_data *req, _o_unused const char *method,
 		struct blob_attr *msg)
 {
 	const struct blobmsg_policy *policy = reconfigure_dhcp_policy;
@@ -933,17 +933,17 @@ static int ubus_handle_reconfigure_dhcp(_unused struct ubus_context *ctx, _unuse
 	return valid_args ? UBUS_STATUS_OK : UBUS_STATUS_INVALID_ARGUMENT;
 }
 
-static int ubus_handle_renew(_unused struct ubus_context *ctx, _unused struct ubus_object *obj,
-		_unused struct ubus_request_data *req, _unused const char *method,
-		_unused struct blob_attr *msg)
+static int ubus_handle_renew(_o_unused struct ubus_context *ctx, _o_unused struct ubus_object *obj,
+		_o_unused struct ubus_request_data *req, _o_unused const char *method,
+		_o_unused struct blob_attr *msg)
 {
 	raise(SIGUSR1);
 	return UBUS_STATUS_OK;
 }
 
-static int ubus_handle_release(_unused struct ubus_context *ctx, _unused struct ubus_object *obj,
-		_unused struct ubus_request_data *req, _unused const char *method,
-		_unused struct blob_attr *msg)
+static int ubus_handle_release(_o_unused struct ubus_context *ctx, _o_unused struct ubus_object *obj,
+		_o_unused struct ubus_request_data *req, _o_unused const char *method,
+		_o_unused struct blob_attr *msg)
 {
 	raise(SIGUSR2);
 	return UBUS_STATUS_OK;


### PR DESCRIPTION
A header file in the Linux kernel on powerpc uses the variable name _unused. This causes the following compile error:
```
In file included from /staging_dir/toolchain-powerpc_8548_gcc-14.3.0_musl/include/signal.h:48,
                 from /staging_dir/target-powerpc_8548_musl/usr/include/libubox/uloop.h:25,
                 from /staging_dir/target-powerpc_8548_musl/usr/include/libubus.h:24,
                 from /build_dir/target-powerpc_8548_musl/odhcp6c-2025.11.04~b3e1db42/src/ubus.h:67,
                 from /build_dir/target-powerpc_8548_musl/odhcp6c-2025.11.04~b3e1db42/src/ubus.c:73:
/staging_dir/toolchain-powerpc_8548_gcc-14.3.0_musl/include/bits/signal.h:27:30: error: expected identifier or '(' before '[' token
   27 |         unsigned long _unused[4];
      |                              ^
ninja: build stopped: subcommand failed.
make[3]: *** [Makefile:62: /build_dir/target-powerpc_8548_musl/odhcp6c-2025.11.04~b3e1db42/.built] Error 1
```

Use _o_unused instead to avoid such conflicts.