### PR TITLE
dhcpv6: restart DHCPv6 transaction on receipt of RA containing a new prefix

### DIFF
--- a/src/dhcpv6.c
+++ b/src/dhcpv6.c
@@ -1661,10 +1661,19 @@ static unsigned int dhcpv6_parse_ia(void *opt, void *end, int *ret)
 
 	// Update address IA
 	dhcpv6_for_each_option(&ia_hdr[1], end, otype, olen, odata) {
-		struct odhcp6c_entry entry = {IN6ADDR_ANY_INIT, 0, 0,
-				IN6ADDR_ANY_INIT, 0, 0, 0, 0, 0, 0};
-
-		entry.iaid = ia_hdr->iaid;
+		struct odhcp6c_entry entry = {
+			.router = IN6ADDR_ANY_INIT,
+			.auxlen = 0,
+			.length = 0,
+			.ra_flags = 0,
+			.target = IN6ADDR_ANY_INIT,
+			.priority = 0,
+			.valid = 0,
+			.preferred = 0,
+			.t1 = 0,
+			.t2 = 0,
+			.iaid = ia_hdr->iaid,
+		};
 
 		switch (otype) {
 		case DHCPV6_OPT_IA_PREFIX: {

--- a/src/odhcp6c.h
+++ b/src/odhcp6c.h
@@ -481,6 +481,7 @@ struct odhcp6c_entry {
 	struct in6_addr router;
 	uint8_t auxlen;
 	uint8_t length;
+	uint8_t ra_flags;
 	struct in6_addr target;
 	int16_t priority;
 	uint32_t valid;

--- a/src/ra.c
+++ b/src/ra.c
@@ -430,6 +430,7 @@ bool ra_process(void)
 		entry->target = any;
 		entry->length = 0;
 		entry->router = from.sin6_addr;
+		entry->ra_flags = adv->nd_ra_flags_reserved & (ND_RA_FLAG_MANAGED | ND_RA_FLAG_OTHER);
 		entry->priority = pref_to_priority(adv->nd_ra_flags_reserved);
 		if (entry->priority < 0)
 			entry->priority = pref_to_priority(0);
@@ -438,6 +439,7 @@ bool ra_process(void)
 		entry->preferred = entry->valid;
 		changed |= odhcp6c_update_entry(STATE_RA_ROUTE, entry,
 						ra_holdoff_interval);
+		entry->ra_flags = 0; // other STATE_RA_* entries don't have flags
 
 		// Parse hop limit
 		changed |= ra_set_hoplimit(adv->nd_ra_curhoplimit);


### PR DESCRIPTION
@Alphix This is the gist of it (no pun). 

===
When the upstream DHCPv6 server does not provide IA_NA or IA_PD options, odhcp6c enters into stateless mode, which will not be exited from until SIGUSR2 signal is received.

This change enforces DHCPv6 transaction restart on receipt of a RA that:
  a) advertises the presence of DHCPv6 server on the network, either
     by containing M or O flags
  b) has a PI (prefix information) option that contains a new prefix

thus allowing the switch to DHCPv6 stateful mode when RA PI options suggest that the upstream DHCPv6 server now manages a new prefix.

Transaction restart is useful even when DHCPv6 client is already in stateful mode, so the DHCPv6 server will be able to refresh the client's IA_NA and IA_PD options before renewal timeout is triggered, hence avoiding the usage of potentially deprecated addresses.

===

This is to supersede #75 