### PR TITLE
src: fix shadowed local variables

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -27,8 +27,10 @@ target_compile_options(${PROJECT_NAME} PRIVATE -Wformat)
 target_compile_options(${PROJECT_NAME} PRIVATE -Werror=format-security)
 target_compile_options(${PROJECT_NAME} PRIVATE -Werror=format-nonliteral)
 target_compile_options(${PROJECT_NAME} PRIVATE -Wimplicit-fallthrough=5)
+target_compile_options(${PROJECT_NAME} PRIVATE -Wno-shadow=compatible-local)
 target_compile_options(${PROJECT_NAME} PRIVATE -Wno-unused-parameter)
 target_compile_options(${PROJECT_NAME} PRIVATE -Wmissing-declarations)
+target_compile_options(${PROJECT_NAME} PRIVATE -Wshadow=local)
 
 
 # Libraries


### PR DESCRIPTION
Fix shadowed local variables and enable warning to prevent more shadowed variables in the future.