### PR TITLE
odhcp6c: accept EUI64 and random for interface ID

### DIFF
--- a/src/odhcp6c.h
+++ b/src/odhcp6c.h
@@ -68,6 +68,9 @@
 #define DHCPV6_DEC_INIT_RT 1
 #define DHCPV6_DEC_MAX_RC 4
 
+#define DHCPV6_IFACEID_EUI64 "eui64"
+#define DHCPV6_IFACEID_RANDOM "random"
+
 #define RA_MIN_ADV_INTERVAL 3   /* RFC 4861 paragraph 6.2.1 */
 
 /* RFC8910 §2 */
@@ -592,5 +595,22 @@ void odhcp6c_expire(bool expire_ia_pd);
 uint32_t odhcp6c_elapsed(void);
 struct odhcp6c_opt *odhcp6c_find_opt(const uint16_t code);
 struct odhcp6c_opt *odhcp6c_find_opt_by_name(const char *name);
+
+static inline bool odhcp6c_is_multicast_ether_addr(const uint8_t *addr)
+{
+	return addr[0] & 0x01;
+}
+
+static inline bool odhcp6c_is_zero_ether_addr(const uint8_t *addr)
+{
+	return (addr[0] | addr[1] | addr[2] |
+		addr[3] | addr[4] | addr[5]) == 0;
+}
+
+static inline bool odhcp6c_is_valid_ether_addr(const uint8_t *addr)
+{
+	return !odhcp6c_is_multicast_ether_addr(addr) &&
+	       !odhcp6c_is_zero_ether_addr(addr);
+}
 
 #endif /* _ODHCP6C_H_ */

--- a/src/ra.h
+++ b/src/ra.h
@@ -48,6 +48,13 @@ struct icmpv6_opt_route_info {
 	uint8_t prefix[];
 };
 
+typedef enum ra_ifid_mode {
+	RA_IFID_EUI64,
+	RA_IFID_FIXED,
+	RA_IFID_RANDOM,
+	RA_IFID_LLA,
+} ra_ifid_mode_t;
+
 #define ND_OPT_ROUTE_INFORMATION 24
 #define ND_OPT_CAPTIVE_PORTAL 37
 
@@ -59,7 +66,8 @@ struct icmpv6_opt_route_info {
 
 
 int ra_init(const char *ifname, const struct in6_addr *ifid,
-		unsigned int options, unsigned int holdoff_interval);
+	    ra_ifid_mode_t ifid_mode, unsigned int options,
+	    unsigned int holdoff_interval);
 bool ra_link_up(void);
 bool ra_process(void);
 


### PR DESCRIPTION
ip6ifaceid is now properly passed to odhcp6c in OpenWrt scripts, which is broken if we don't support 'eui64' and 'random' options.

Closes https://github.com/openwrt/openwrt/issues/20976

Draft until we support EUI64 (default - no parameter is LLA which can be different to EUI64).