### PR TITLE
odhcp6c: fix "-S" usage

### DIFF
--- a/src/odhcp6c.c
+++ b/src/odhcp6c.c
@@ -776,7 +776,7 @@ static int usage(void)
 	const char buf[] =
 	"Usage: odhcp6c [options] <interface>\n"
 	"\nFeature options:\n"
-	"	-S <time>	Wait at least <time> sec for a DHCP-server (0)\n"
+	"	-S		Don't allow configuration via SLAAC (RAs) only\n"
 	"	-D		Discard advertisements without any address or prefix proposed\n"
 	"	-N <mode>	Mode for requesting addresses [try|force|none]\n"
 	"	-P <[pfx/]len>	Request IPv6-Prefix (0 = auto)\n"


### PR DESCRIPTION
Commit 1d6c4e794cdb converted "-S" option from integer to boolean, but usage wasn't properly updated.

Fixes: 1d6c4e794cdb ("src: convert allow_slaac_only to boolean")

CC @systemcrash @Alphix 