### PR TITLE
dhcpv6: use stable IAID for IA_NA

### DIFF
--- a/src/odhcp6c.h
+++ b/src/odhcp6c.h
@@ -540,6 +540,7 @@ struct odhcp6c_opt {
 	const char *str;
 };
 
+uint32_t hash_ifname(const char *s);
 int init_dhcpv6(const char *ifname);
 int dhcpv6_get_ia_mode(void);
 int dhcpv6_promote_server_cand(void);


### PR DESCRIPTION
https://www.rfc-editor.org/rfc/rfc8415.html#section-12

   ........  The IAID is chosen by the client.  For any given use of an
   IA by the client, the IAID for that IA MUST be consistent across
   restarts of the DHCP client.  The client may maintain consistency by
   either storing the IAID in non-volatile storage or using an algorithm
   that will consistently produce the same IAID as long as the
   configuration of the client has not changed.

ping @Alphix @Noltari 