### PR TITLE
all: add log helpers

### DIFF
--- a/src/config.h
+++ b/src/config.h
@@ -83,7 +83,9 @@ enum config_dhcp_msg {
 };
 
 struct config_dhcp {
+	bool log_syslog;
 	bool release;
+	int log_level;
 	int dscp;
 	int sk_prio;
 	bool stateful_only_mode;

--- a/src/odhcp6c.h
+++ b/src/odhcp6c.h
@@ -19,6 +19,7 @@
 #include <netinet/in.h>
 #include <stdbool.h>
 #include <stdint.h>
+#include <syslog.h>
 
 #ifndef _o_aligned
 #define _o_aligned(n) __attribute__((aligned(n)))
@@ -37,6 +38,16 @@
 #endif /* _o_unused */
 
 #define ARRAY_SIZE(arr) (sizeof(arr) / sizeof((arr)[0]))
+
+void __iflog(int lvl, const char *fmt, ...);
+#define debug(fmt, ...) __iflog(LOG_DEBUG, fmt __VA_OPT__(, ) __VA_ARGS__)
+#define info(fmt, ...) __iflog(LOG_INFO, fmt __VA_OPT__(, ) __VA_ARGS__)
+#define notice(fmt, ...) __iflog(LOG_NOTICE, fmt __VA_OPT__(, ) __VA_ARGS__)
+#define warn(fmt, ...) __iflog(LOG_WARNING, fmt __VA_OPT__(, ) __VA_ARGS__)
+#define error(fmt, ...) __iflog(LOG_ERR, fmt __VA_OPT__(, ) __VA_ARGS__)
+#define critical(fmt, ...) __iflog(LOG_CRIT, fmt __VA_OPT__(, ) __VA_ARGS__)
+#define alert(fmt, ...) __iflog(LOG_ALERT, fmt __VA_OPT__(, ) __VA_ARGS__)
+#define emergency(fmt, ...) __iflog(LOG_EMERG, fmt __VA_OPT__(, ) __VA_ARGS__)
 
 #define ND_OPT_RECURSIVE_DNS 25
 #define ND_OPT_DNSSL 31

--- a/src/script.c
+++ b/src/script.c
@@ -22,7 +22,6 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-#include <syslog.h>
 #include <sys/wait.h>
 #include <unistd.h>
 
@@ -500,7 +499,7 @@ void script_call(const char *status, int delay, bool resume)
 		if (capt_port_ra_len > 0 && capt_port_dhcpv6_len > 0) {
 			if (capt_port_ra_len != capt_port_dhcpv6_len ||
 				!memcmp(capt_port_dhcpv6, capt_port_ra, capt_port_dhcpv6_len))
-				syslog(LOG_ERR,
+				error(
 					"%s received via different vectors differ: preferring URI from DHCPv6",
 					CAPT_PORT_URI_STR);
 		}

--- a/src/ubus.c
+++ b/src/ubus.c
@@ -65,7 +65,6 @@
 #include <resolv.h>
 #include <stdio.h>
 #include <sys/types.h>
-#include <syslog.h>
 
 #include "config.h"
 #include "odhcp6c.h"
@@ -76,7 +75,7 @@
 		int ret = (stmt); \
 		if (ret != UBUS_STATUS_OK) \
 		{ \
-			syslog(LOG_ERR, "%s failed: %s (%d)", #stmt, ubus_strerror(ret), ret); \
+			error("%s failed: %s (%d)", #stmt, ubus_strerror(ret), ret); \
 			return ret; \
 		} \
 	} while (0)
@@ -195,7 +194,7 @@ static void ubus_disconnect_cb(struct ubus_context *ubus)
 
 	ret = ubus_reconnect(ubus, NULL);
 	if (ret) {
-		syslog(LOG_ERR, "Cannot reconnect to ubus: %s", ubus_strerror(ret));
+		error("Cannot reconnect to ubus: %s", ubus_strerror(ret));
 		ubus_destroy(ubus);
 	}
 }
@@ -227,7 +226,7 @@ struct ubus_context *ubus_get_ctx(void)
 
 void ubus_destroy(struct ubus_context *ubus)
 {
-	syslog(LOG_NOTICE, "Disconnecting from ubus");
+	notice("Disconnecting from ubus");
 
 	if (ubus != NULL)
 		ubus_free(ubus);
@@ -565,7 +564,7 @@ static int states_to_blob(void)
 	if (capt_port_ra_len > 0 && capt_port_dhcpv6_len > 0) {
 		if (capt_port_ra_len != capt_port_dhcpv6_len ||
 			!memcmp(capt_port_dhcpv6, capt_port_ra, capt_port_dhcpv6_len))
-			syslog(LOG_ERR,
+			error(
 				"%s received via different vectors differ: preferring URI from DHCPv6",
 				CAPT_PORT_URI_STR);
 	}


### PR DESCRIPTION
avoids multiple `syslog.h` include

(sync with implementation in odhcpd)

ping @Alphix and @Noltari 

We deprecate the `-v` param. Add new `-l` param for level, identical to odhcpd. 

The odhcp6c `dhcpv6.sh` script in openwrt main should be updated
to recognize this change, but it is harmless if it is not changed.

If not, odhcp6c just defaults to its normal logging behaviour, and verbosity flag won't print more.

```diff
diff --git a/package/network/ipv6/odhcp6c/files/dhcpv6.sh b/package/network/ipv6/odhcp6c/files/dhcpv6.sh
index 59a6021c5c..4196d65e8f 100755
--- a/package/network/ipv6/odhcp6c/files/dhcpv6.sh
+++ b/package/network/ipv6/odhcp6c/files/dhcpv6.sh
@@ -42,7 +42,7 @@ proto_dhcpv6_init_config() {
 	proto_config_add_boolean sourcefilter
 	proto_config_add_boolean keep_ra_dnslifetime
 	proto_config_add_int "ra_holdoff"
-	proto_config_add_boolean verbose
+	proto_config_add_int 'verbose:range(0,7)'
 	proto_config_add_boolean dynamic
 }
 
@@ -116,7 +116,7 @@ proto_dhcpv6_setup() {
 
 	[ -n "$ra_holdoff" ] && append opts "-m$ra_holdoff"
 
-	[ "$verbose" = "1" ] && append opts "-v"
+	[ -n "$verbose" ] && append opts "-l$verbose"
 
 	json_for_each_item proto_dhcpv6_add_sendopts sendopts opts
 

```

Tested and verified. 