### PR TITLE
[25.12] backport fixes/updates from master

### DIFF
--- a/src/config.c
+++ b/src/config.c
@@ -322,9 +322,10 @@ static int config_parse_opt_u8(const char *src, uint8_t **dst)
 {
 	int len = strlen(src);
 
-	*dst = realloc(*dst, len/2);
-	if (!*dst)
+	uint8_t *tmp = realloc(*dst, len/2);
+	if (!tmp)
 		return -1;
+	*dst = tmp;
 
 	return script_unhexlify(*dst, len, src);
 }
@@ -345,9 +346,10 @@ static int config_parse_opt_string(const char *src, uint8_t **dst, const bool ar
 
 		int len = strlen(src);
 
-		*dst = realloc(*dst, o_len + len);
-		if (!*dst)
+		uint8_t *tmp = realloc(*dst, o_len + len);
+		if (!tmp)
 			return -1;
+		*dst = tmp;
 
 		memcpy(&((*dst)[o_len]), src, len);
 
@@ -381,9 +383,10 @@ static int config_parse_opt_dns_string(const char *src, uint8_t **dst, const boo
 		if (len < 0)
 			return -1;
 
-		*dst = realloc(*dst, o_len + len);
-		if (!*dst)
+		uint8_t *dst_tmp = realloc(*dst, o_len + len);
+		if (!dst_tmp)
 			return -1;
+		*dst = dst_tmp;
 
 		memcpy(&((*dst)[o_len]), tmp, len);
 
@@ -413,9 +416,10 @@ static int config_parse_opt_ip6(const char *src, uint8_t **dst, const bool array
 			sep++;
 		}
 
-		*dst = realloc(*dst, o_len + len);
-		if (!*dst)
+		uint8_t *tmp = realloc(*dst, o_len + len);
+		if (!tmp)
 			return -1;
+		*dst = tmp;
 
 		if (inet_pton(AF_INET6, src, &((*dst)[o_len])) < 1)
 			return -1;
@@ -445,9 +449,10 @@ static int config_parse_opt_user_class(const char *src, uint8_t **dst, const boo
 		}
 		uint16_t str_len = strlen(src);
 
-		*dst = realloc(*dst, o_len + str_len + 2);
-		if (!*dst)
+		uint8_t *tmp = realloc(*dst, o_len + str_len + 2);
+		if (!tmp)
 			return -1;
+		*dst = tmp;
 
 		struct user_class {
 			uint16_t len;

--- a/src/config.h
+++ b/src/config.h
@@ -83,7 +83,9 @@ enum config_dhcp_msg {
 };
 
 struct config_dhcp {
+	bool log_syslog;
 	bool release;
+	int log_level;
 	int dscp;
 	int sk_prio;
 	bool stateful_only_mode;

--- a/src/dhcpv6.c
+++ b/src/dhcpv6.c
@@ -986,11 +986,11 @@ static void dhcpv6_send(enum dhcpv6_msg req_msg_type, uint8_t trid[3], uint32_t 
 		case DHCPV6_MSG_REPLY:
 		*/
 			/* leave FQDN as-is */
-		    break;
+			break;
 		default:
 			/* remaining MSG types cannot contain client FQDN */
 			iov[IOV_FQDN].iov_len = 0;
-		    break;
+			break;
 		}
 	}
 

--- a/src/odhcp6c.h
+++ b/src/odhcp6c.h
@@ -272,23 +272,23 @@ typedef int(reply_handler)(enum dhcpv6_msg orig, const int rc,
 
 // retransmission strategy
 struct dhcpv6_retx {
-	uint8_t max_delay;
+	uint8_t max_delay; // Delay before starting transaction
 	uint8_t init_timeo;
 	uint16_t max_timeo;
-	uint8_t max_rc;
+	uint8_t max_rc; // Max Retry Count
 	char name[8];
 	reply_handler *handler_reply;
 	int(*handler_finish)(void);
 	bool is_retransmit;
-	uint64_t timeout;
-	uint8_t rc;
-	uint64_t start;
-	uint8_t tr_id[3];
-	int64_t rto;
-	uint64_t round_start;
-	uint64_t round_end;
-	int reply_ret;
-	uint64_t delay_msec;
+	uint64_t timeout; // Maximum duration (in seconds) for the entire DHCPv6 transaction. Varies based on the message type
+	uint8_t rc; // Retry Count
+	uint64_t start; // Transaction start time (in milliseconds)
+	uint8_t tr_id[3]; // Transaction ID
+	int64_t rto; // Retransmission TimeOut
+	uint64_t round_start; // the (RTT) time when a request was sent (in milliseconds)
+	uint64_t round_end; // the (RTT) time when a response was expected to arrive (in milliseconds)
+	int reply_ret; // Reply handler return value
+	uint64_t delay_msec; // Delay before starting the transaction
 };
 
 #define DHCPV6_OPT_HDR_SIZE 4

--- a/src/odhcp6c.h
+++ b/src/odhcp6c.h
@@ -19,6 +19,7 @@
 #include <netinet/in.h>
 #include <stdbool.h>
 #include <stdint.h>
+#include <syslog.h>
 
 #ifndef _o_aligned
 #define _o_aligned(n) __attribute__((aligned(n)))
@@ -37,6 +38,16 @@
 #endif /* _o_unused */
 
 #define ARRAY_SIZE(arr) (sizeof(arr) / sizeof((arr)[0]))
+
+void __iflog(int lvl, const char *fmt, ...);
+#define debug(fmt, ...) __iflog(LOG_DEBUG, fmt __VA_OPT__(, ) __VA_ARGS__)
+#define info(fmt, ...) __iflog(LOG_INFO, fmt __VA_OPT__(, ) __VA_ARGS__)
+#define notice(fmt, ...) __iflog(LOG_NOTICE, fmt __VA_OPT__(, ) __VA_ARGS__)
+#define warn(fmt, ...) __iflog(LOG_WARNING, fmt __VA_OPT__(, ) __VA_ARGS__)
+#define error(fmt, ...) __iflog(LOG_ERR, fmt __VA_OPT__(, ) __VA_ARGS__)
+#define critical(fmt, ...) __iflog(LOG_CRIT, fmt __VA_OPT__(, ) __VA_ARGS__)
+#define alert(fmt, ...) __iflog(LOG_ALERT, fmt __VA_OPT__(, ) __VA_ARGS__)
+#define emergency(fmt, ...) __iflog(LOG_EMERG, fmt __VA_OPT__(, ) __VA_ARGS__)
 
 #define ND_OPT_RECURSIVE_DNS 25
 #define ND_OPT_DNSSL 31

--- a/src/odhcp6c.h
+++ b/src/odhcp6c.h
@@ -415,6 +415,7 @@ struct dhcpv6_stats {
 enum odhcp6c_state {
 	STATE_CLIENT_ID,
 	STATE_SERVER_ID,
+	STATE_OUR_FQDN,
 	STATE_SERVER_CAND,
 	STATE_SERVER_ADDR,
 	STATE_ORO,

--- a/src/script.c
+++ b/src/script.c
@@ -22,7 +22,6 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-#include <syslog.h>
 #include <sys/wait.h>
 #include <unistd.h>
 
@@ -500,7 +499,7 @@ void script_call(const char *status, int delay, bool resume)
 		if (capt_port_ra_len > 0 && capt_port_dhcpv6_len > 0) {
 			if (capt_port_ra_len != capt_port_dhcpv6_len ||
 				!memcmp(capt_port_dhcpv6, capt_port_ra, capt_port_dhcpv6_len))
-				syslog(LOG_ERR,
+				error(
 					"%s received via different vectors differ: preferring URI from DHCPv6",
 					CAPT_PORT_URI_STR);
 		}

--- a/src/ubus.c
+++ b/src/ubus.c
@@ -65,7 +65,6 @@
 #include <resolv.h>
 #include <stdio.h>
 #include <sys/types.h>
-#include <syslog.h>
 
 #include "config.h"
 #include "odhcp6c.h"
@@ -76,7 +75,7 @@
 		int ret = (stmt); \
 		if (ret != UBUS_STATUS_OK) \
 		{ \
-			syslog(LOG_ERR, "%s failed: %s (%d)", #stmt, ubus_strerror(ret), ret); \
+			error("%s failed: %s (%d)", #stmt, ubus_strerror(ret), ret); \
 			return ret; \
 		} \
 	} while (0)
@@ -195,7 +194,7 @@ static void ubus_disconnect_cb(struct ubus_context *ubus)
 
 	ret = ubus_reconnect(ubus, NULL);
 	if (ret) {
-		syslog(LOG_ERR, "Cannot reconnect to ubus: %s", ubus_strerror(ret));
+		error("Cannot reconnect to ubus: %s", ubus_strerror(ret));
 		ubus_destroy(ubus);
 	}
 }
@@ -227,7 +226,7 @@ struct ubus_context *ubus_get_ctx(void)
 
 void ubus_destroy(struct ubus_context *ubus)
 {
-	syslog(LOG_NOTICE, "Disconnecting from ubus");
+	notice("Disconnecting from ubus");
 
 	if (ubus != NULL)
 		ubus_free(ubus);
@@ -565,7 +564,7 @@ static int states_to_blob(void)
 	if (capt_port_ra_len > 0 && capt_port_dhcpv6_len > 0) {
 		if (capt_port_ra_len != capt_port_dhcpv6_len ||
 			!memcmp(capt_port_dhcpv6, capt_port_ra, capt_port_dhcpv6_len))
-			syslog(LOG_ERR,
+			error(
 				"%s received via different vectors differ: preferring URI from DHCPv6",
 				CAPT_PORT_URI_STR);
 	}


### PR DESCRIPTION
- ra: convert if block to switch
- odhcp6c: do cleanup at exit
- config: fix potential memory leaks in error paths
- all: add log helpers
- dhcpv6: clarifying comments
- dhcpv6: offload FQDN construction to init_dhcpv6
- dhcpv6: migrate dhcpv6_response_is_valid to switch case

~~Draft until #147 is merged.~~