### PR TITLE
dhcpv6: add config for strict RFC7550

### DIFF
--- a/src/config.c
+++ b/src/config.c
@@ -318,6 +318,11 @@ bool config_set_auth_token(const char* token)
 	return config_dhcp.auth_token != NULL;
 }
 
+void config_set_client_opt_cfg(struct odhcp6c_opt_cfg *opt_cfg)
+{
+	config_dhcp.strict_rfc7550 = opt_cfg->strict_rfc7550 != 0;
+}
+
 static int config_parse_opt_u8(const char *src, uint8_t **dst)
 {
 	int len = strlen(src);

--- a/src/config.h
+++ b/src/config.h
@@ -100,6 +100,7 @@ struct config_dhcp {
 	uint16_t rand_factor;
 	enum odhcp6c_auth_protocol auth_protocol;
 	char* auth_token;
+	bool strict_rfc7550;
 };
 
 struct config_dhcp *config_dhcp_get(void);
@@ -126,6 +127,7 @@ bool config_set_irt_min(unsigned int value);
 bool config_set_rand_factor(unsigned int value);
 bool config_set_auth_protocol(const char* protocol);
 bool config_set_auth_token(const char* token);
+void config_set_client_opt_cfg(struct odhcp6c_opt_cfg *opt_cfg);
 
 int config_add_opt(const uint16_t code, const uint8_t *data, const uint16_t len);
 int config_parse_opt_data(const char *data, uint8_t **dst, const unsigned int type, const bool array);

--- a/src/odhcp6c.h
+++ b/src/odhcp6c.h
@@ -552,6 +552,10 @@ struct odhcp6c_opt {
 	const char *str;
 };
 
+struct odhcp6c_opt_cfg {
+	int strict_rfc7550;
+};
+
 uint32_t hash_ifname(const char *s);
 int init_dhcpv6(const char *ifname);
 int dhcpv6_get_ia_mode(void);


### PR DESCRIPTION
Some ISPs don't comply with RFC7550 and need workarounds to get proper IPv6 connectivity.

ping @Ansuel @systemcrash @Alphix 