### PR TITLE
script: sanitize environment variables

### DIFF
--- a/src/script.c
+++ b/src/script.c
@@ -94,6 +94,66 @@ void script_hexlify(char *dst, const uint8_t *src, size_t len)
 	*dst = 0;
 }
 
+/*
+ * Prepare an already-assembled "NAME=value" buffer that originates from
+ * untrusted network input before it is exported to the environment of the
+ * (root) status script.
+ *
+ * The variable NAME (the bytes before the first '=') is validated, not
+ * rewritten. It is only accepted if it is a non-empty run of the portable
+ * environment-variable charset ([A-Za-z_][A-Za-z0-9_]*). Silently rewriting an
+ * invalid name could map a value onto an unexpected variable, so a missing or
+ * invalid name causes the whole entry to be rejected: the function returns
+ * false and the caller must not putenv() it. Rejecting a single entry (rather
+ * than aborting the process) avoids handing an attacker a denial-of-service
+ * trigger. The names used in this file are compile-time constants, so this is
+ * defense in depth against future call sites.
+ *
+ * The value (the bytes after the first '=') is sanitized in place. DHCPv6
+ * replies and ICMPv6 Router Advertisements are attacker-controlled, so option
+ * payloads may contain newlines or other non-printable bytes. Any byte that is
+ * not printable ASCII, or that could trigger shell quoting/expansion, is
+ * replaced with '_'. This cannot remove embedded NUL bytes (they already
+ * terminate the C string) and does not by itself guarantee shell-safety: the
+ * consuming script must still quote variables.
+ *
+ * Returns true if the entry is safe to export, false if it must be discarded.
+ */
+static bool script_sanitize_env(char *env)
+{
+	char *p = strchr(env, '=');
+
+	/* A well-formed entry must have a non-empty NAME before the '='. */
+	if (p == NULL || p == env)
+		return false;
+
+	/* Validate the NAME without modifying it. */
+	for (char *n = env; n < p; n++) {
+		unsigned char c = (unsigned char)*n;
+
+		if (c == '_' || (c >= 'A' && c <= 'Z') || (c >= 'a' && c <= 'z'))
+			continue;
+		/* Digits are allowed, but not as the first character. */
+		if (n != env && c >= '0' && c <= '9')
+			continue;
+
+		return false;
+	}
+
+	/* Sanitize the value portion in place. */
+	for (p++; *p; p++) {
+		unsigned char c = (unsigned char)*p;
+
+		/* Replace anything that is not printable ASCII, or that could
+		 * trigger shell quoting/expansion, with '_'. A regular space
+		 * is left intact because values are space-separated lists. */
+		if (c < 0x20 || c > 0x7e || strchr("`$\\\"'", c))
+			*p = '_';
+	}
+
+	return true;
+}
+
 static void ipv6_to_env(const char *name,
 		const struct in6_addr *addr, size_t cnt)
 {
@@ -116,6 +176,7 @@ static void ipv6_to_env(const char *name,
 		buf_len--;
 
 	buf[buf_len] = '\0';
+	/* Values come solely from inet_ntop(AF_INET6, ...) — charset is safe. */
 	putenv(buf);
 }
 
@@ -145,7 +206,11 @@ static void fqdn_to_env(const char *name, const uint8_t *fqdn, size_t len)
 		buf_len--;
 
 	buf[buf_len] = '\0';
-	putenv(buf);
+	/* DNS names from server; dn_expand output may contain attacker bytes. */
+	if (script_sanitize_env(buf))
+		putenv(buf);
+	else
+		free(buf);
 }
 
 static void string_to_env(const char *name, const uint8_t *string, size_t len)
@@ -160,7 +225,11 @@ static void string_to_env(const char *name, const uint8_t *string, size_t len)
 	buf[name_len] = '=';
 	memcpy(&buf[name_len + 1], string, len);
 	buf[name_len + 1 + len] = '\0';
-	putenv(buf);
+	/* Value is server-supplied (e.g. captive-portal URI); sanitize it. */
+	if (script_sanitize_env(buf))
+		putenv(buf);
+	else
+		free(buf);
 }
 
 static void bin_to_env(uint8_t *opts, size_t len)
@@ -178,6 +247,7 @@ static void bin_to_env(uint8_t *opts, size_t len)
 		snprintf(buf, 14, "OPTION_%hu=", otype);
 		buf_len += strlen(buf);
 
+		/* Value is hexlified by script_hexlify — charset is safe. */
 		script_hexlify(&buf[buf_len], odata, olen);
 		putenv(buf);
 	}
@@ -297,7 +367,11 @@ static void search_to_env(const char *name, const uint8_t *start, size_t len)
 		c--;
 
 	*c = '\0';
-	putenv(buf);
+	/* DNS search list from RA; auxtarget bytes are attacker-controlled. */
+	if (script_sanitize_env(buf))
+		putenv(buf);
+	else
+		free(buf);
 }
 
 static void int_to_env(const char *name, int value)
@@ -309,6 +383,7 @@ static void int_to_env(const char *name, int value)
 		return;
 
 	snprintf(buf, len, "%s=%d", name, value);
+	/* Value is snprintf("%d") — charset is safe. */
 	putenv(buf);
 }
 
@@ -438,7 +513,11 @@ static void s46_to_env(enum odhcp6c_state state, const uint8_t *data, size_t len
 	}
 
 	fclose(fp);
-	putenv(str);
+	/* Built from inet_ntop/fprintf on untrusted option data; sanitize for defense in depth. */
+	if (script_sanitize_env(str))
+		putenv(str);
+	else
+		free(str);
 }
 
 void script_call(const char *status, int delay, bool resume)


### PR DESCRIPTION
Introduce `script_sanitize_env()` to validate and sanitize `NAME=value` strings assembled from untrusted DHCPv6/RA network input before they are exported via `putenv()` to the (root-executed) status script.

- **NAME validation**: rejects entries whose variable name does not conform to `[A-Za-z_][A-Za-z0-9_]*`; an invalid name causes the entire entry to be silently dropped rather than silently remapped.
- **Value sanitization**: replaces non-printable, non-ASCII, and shell-significant bytes (`` ` ``, `$`, `\`, `"`, `'`, non-space whitespace) with `_` in place, defending against newline injection and shell expansion via attacker-controlled option payloads.
- Apply sanitization to all paths that carry server-supplied data: `fqdn_to_env`, `string_to_env`, `search_to_env`, and `s46_to_env`. Paths whose values are solely produced by `inet_ntop`/`snprintf("%d")`/`script_hexlify` are documented as safe and left unsanitized.
