### PR TITLE
config: drop misleading const from option-parsing input strings

### DIFF
--- a/src/config.c
+++ b/src/config.c
@@ -344,7 +344,7 @@ static int config_parse_opt_u8(const char *src, uint8_t **dst)
 	return script_unhexlify(*dst, len, src);
 }
 
-static int config_parse_opt_string(const char *src, uint8_t **dst, const bool array)
+static int config_parse_opt_string(char *src, uint8_t **dst, const bool array)
 {
 	int o_len = 0;
 	char *sep = strpbrk(src, ARRAY_SEP);
@@ -377,7 +377,7 @@ static int config_parse_opt_string(const char *src, uint8_t **dst, const bool ar
 	return o_len;
 }
 
-static int config_parse_opt_dns_string(const char *src, uint8_t **dst, const bool array)
+static int config_parse_opt_dns_string(char *src, uint8_t **dst, const bool array)
 {
 	int o_len = 0;
 	char *sep = strpbrk(src, ARRAY_SEP);
@@ -414,7 +414,7 @@ static int config_parse_opt_dns_string(const char *src, uint8_t **dst, const boo
 	return o_len;
 }
 
-static int config_parse_opt_ip6(const char *src, uint8_t **dst, const bool array)
+static int config_parse_opt_ip6(char *src, uint8_t **dst, const bool array)
 {
 	int o_len = 0;
 	char *sep = strpbrk(src, ARRAY_SEP);
@@ -448,7 +448,7 @@ static int config_parse_opt_ip6(const char *src, uint8_t **dst, const bool array
 	return o_len;
 }
 
-static int config_parse_opt_user_class(const char *src, uint8_t **dst, const bool array)
+static int config_parse_opt_user_class(char *src, uint8_t **dst, const bool array)
 {
 	int o_len = 0;
 	char *sep = strpbrk(src, ARRAY_SEP);
@@ -519,7 +519,7 @@ int config_add_opt(const uint16_t code, const uint8_t *data, const uint16_t len)
 	return 0;
 }
 
-int config_parse_opt_data(const char *data, uint8_t **dst, const unsigned int type,
+int config_parse_opt_data(char *data, uint8_t **dst, const unsigned int type,
 		const bool array)
 {
 	int ret = 0;
@@ -553,7 +553,7 @@ int config_parse_opt_data(const char *data, uint8_t **dst, const unsigned int ty
 	return ret;
 }
 
-int config_parse_opt(const char *opt)
+int config_parse_opt(char *opt)
 {
 	uint32_t optn;
 	char *data;

--- a/src/config.h
+++ b/src/config.h
@@ -130,8 +130,8 @@ bool config_set_auth_token(const char* token);
 void config_set_client_opt_cfg(struct odhcp6c_opt_cfg *opt_cfg);
 
 int config_add_opt(const uint16_t code, const uint8_t *data, const uint16_t len);
-int config_parse_opt_data(const char *data, uint8_t **dst, const unsigned int type, const bool array);
-int config_parse_opt(const char *opt);
+int config_parse_opt_data(char *data, uint8_t **dst, const unsigned int type, const bool array);
+int config_parse_opt(char *opt);
 
 void config_apply_dhcp_rtx(struct dhcpv6_retx* dhcpv6_retx);
 


### PR DESCRIPTION
config_parse_opt(), config_parse_opt_data() and the array option parsers (string/dns_string/ip6/user_class) declared their input as const char *, yet write through it in place (*sep = 0, *data = '\0', *end = '\0') to split the value on ARRAY_SEP / ':'. The const was therefore inaccurate, and only worked because strpbrk() historically returned char * regardless of input qualifier.

GCC 15+ defaults to C23, where the C23 const-correct strpbrk() returns const char * for a const char * argument, so assigning to the char *sep that is then written through triggers -Wdiscarded-qualifiers (a build break under -Werror). Reproduced with gcc 16.1.1:

  warning: initialization discards 'const' qualifier from pointer
  target type [-Wdiscarded-qualifiers]

Rather than cast the qualifier away at every call site, drop the const so the signatures honestly reflect that these helpers mutate their input. All callers already pass writable buffers (getopt's optarg and a strdup() copy in config_add_send_options()). config_parse_opt_u8() keeps its const as it only reads.

No functional change; compiles clean under both -std=gnu11 and -std=c23 with -Werror.