### PR TITLE
ra: validate ND_OPT_MTU option length before reading MTU value

### DIFF
--- a/src/ra.c
+++ b/src/ra.c
@@ -594,8 +594,15 @@ bool ra_process(void)
 		icmpv6_for_each_option(opt, &adv[1], &buf[len]) {
 			switch(opt->type) {
 			case ND_OPT_MTU:
-				uint32_t *mtu = (uint32_t*)&opt->data[2];
-				changed |= ra_set_mtu(ntohl(*mtu));
+				if (opt->len != 1)
+					continue;
+
+				if ((uint8_t*)&opt->data[2] + sizeof(uint32_t) > &buf[len])
+					continue;
+
+				uint32_t mtu;
+				memcpy(&mtu, &opt->data[2], sizeof(mtu));
+				changed |= ra_set_mtu(ntohl(mtu));
 				break;
 
 			case ND_OPT_ROUTE_INFORMATION:


### PR DESCRIPTION
Per RFC 4861 §4.6.4 the MTU option has a fixed length of 1 (8 octets). Add the missing opt->len check so a short/malformed option is ignored rather than read out-of-bounds.  Also add an explicit bounds check and replace the misaligned uint32_t* cast with a memcpy-based read, matching the alignment-safe style used elsewhere in the file.