### PR TITLE
ra: add bounds check for captive-portal URI bytes

### DIFF
--- a/src/ra.c
+++ b/src/ra.c
@@ -731,6 +731,9 @@ bool ra_process(void)
 				struct icmpv6_opt_captive_portal *capt_port = (struct icmpv6_opt_captive_portal*)opt;
 				uint8_t *cp_buf = &capt_port->data[0];
 				size_t uri_len = (capt_port->len * 8) - 2;
+				if (cp_buf + uri_len > &buf[len])
+					continue;
+
 				size_t ref_len = sizeof(URN_IETF_CAPT_PORT_UNRESTR) - 1;
 
 				/* RFC8910 §2:


### PR DESCRIPTION
Guards against a malicious or malformed Router Advertisement whose captive portal option claims a URI longer than the bytes actually received. `capt_port->len` is attacker-controlled, so `(len * 8) - 2` could point past the end of `buf`. Without the check, the later `memcmp` / `odhcp6c_add_state(..., cp_buf, uri_len)` would read out of bounds (heap/stack over-read → crash or info leak).