### PR TITLE
odhcp6c: fix stale/freed ubus context in main poll loop

### DIFF
--- a/src/odhcp6c.c
+++ b/src/odhcp6c.c
@@ -841,6 +841,19 @@ int main(_o_unused int argc, char* const argv[])
 		if (signal_usr2 || signal_term)
 			dhcpv6_set_state(DHCPV6_EXIT);
 
+#ifdef WITH_UBUS
+		/*
+		 * The connection_lost callback may call ubus_reconnect(), which
+		 * allocates a fresh socket, or destroy the context entirely if
+		 * the reconnect fails. Re-fetch the context and refresh the
+		 * polled fd each iteration so we never poll a stale descriptor
+		 * or dereference a freed context; a NULL context disables the
+		 * ubus slot by polling fd = -1.
+		 */
+		ubus = ubus_get_ctx();
+		fds[UBUS_FD_INDEX].fd = ubus ? ubus->sock.fd : -1;
+#endif /* WITH_UBUS */
+
 		poll_res = poll(fds, nfds, dhcpv6_get_state_timeout());
 		dhcpv6_reset_state_timeout();
 		if (poll_res == -1 && (errno == EINTR || errno == EAGAIN)) {
@@ -859,7 +872,7 @@ int main(_o_unused int argc, char* const argv[])
 	notify_state_change("stopped", 0, true);
 
 #ifdef WITH_UBUS
-	ubus_destroy(ubus);
+	ubus_destroy(ubus_get_ctx());
 #endif /* WITH_UBUS */
 
 	return 0;

--- a/src/ubus.c
+++ b/src/ubus.c
@@ -224,12 +224,17 @@ struct ubus_context *ubus_get_ctx(void)
 	return ubus;
 }
 
-void ubus_destroy(struct ubus_context *ubus)
+void ubus_destroy(struct ubus_context *ctx)
 {
 	notice("Disconnecting from ubus");
 
-	if (ubus != NULL)
-		ubus_free(ubus);
+	if (ctx != NULL)
+		ubus_free(ctx);
+	/*
+	 * Clear the cached global so ubus_get_ctx() returns NULL after a
+	 * teardown (e.g. a failed reconnect). Previously the parameter
+	 * shadowed the global, leaving it dangling at a freed context.
+	 */
 	ubus = NULL;
 
 	/* Forces re-initialization when we're reusing the same definitions later on. */


### PR DESCRIPTION
The ubus socket fd was captured once during init and stored in the poll set (fds[UBUS_FD_INDEX].fd), and the ubus context pointer was likewise cached as a local in the main loop. Neither was ever refreshed.

When the ubus connection drops, the connection_lost callback (ubus_disconnect_cb) runs:

  - On a successful ubus_reconnect(), a new socket is allocated and ubus->sock.fd changes. Because the poll set kept the old fd, after the first reconnect the loop polled a stale, closed descriptor (POLLNVAL) and ubus events stopped being delivered.

  - On a failed reconnect, ubus_destroy() frees the context. The cached pointer in main() then dangled, so any later use (the polled fd, ubus_handle_event(), the final ubus_destroy()) was a use-after-free.

Additionally, ubus_destroy()'s parameter shadowed the file-scope global "ubus", so its "ubus = NULL" assignment only cleared the parameter and left the global pointing at freed memory; ubus_get_ctx() would then return a freed pointer instead of NULL.

Fix all three issues:

  - Rename the ubus_destroy() parameter to "ctx" so the assignment actually clears the global; ubus_get_ctx() now returns NULL after teardown.
  - Re-fetch the context via ubus_get_ctx() and refresh the polled fd each loop iteration, polling fd = -1 when the context is NULL so the ubus slot is disabled gracefully (a -1 fd never reports POLLIN, so ubus_handle_event() is correctly skipped).
  - Re-fetch the context for the final ubus_destroy() to avoid a double free if the last iteration's event triggered a failed reconnect.